### PR TITLE
Fix for JENKINS-10637, JENKINS-10638 and JENKINS-10754.  Mitigates JENKINS-10719.

### DIFF
--- a/src/main/java/hudson/plugins/accurev/AccurevChangeLogSet.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevChangeLogSet.java
@@ -1,18 +1,18 @@
 package hudson.plugins.accurev;
 
-import hudson.scm.ChangeLogSet;
 import hudson.model.AbstractBuild;
+import hudson.scm.ChangeLogSet;
 
-import java.util.List;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Created by IntelliJ IDEA.
-*
-* @author connollys
-* @since 10-Oct-2007 13:12:40
-*/
+ *
+ * @author connollys
+ * @since 10-Oct-2007 13:12:40
+ */
 final class AccurevChangeLogSet extends ChangeLogSet<AccurevTransaction> {
     private final List<AccurevTransaction> transactions;
 
@@ -34,5 +34,4 @@ final class AccurevChangeLogSet extends ChangeLogSet<AccurevTransaction> {
     public Iterator<AccurevTransaction> iterator() {
         return transactions.iterator();
     }
-
 }

--- a/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
@@ -1,0 +1,465 @@
+package hudson.plugins.accurev;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Launcher.ProcStarter;
+import hudson.model.TaskListener;
+import hudson.util.ArgumentListBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+import org.xmlpull.v1.XmlPullParserFactory;
+
+/**
+ * Utility class that knows how to run AccuRev commands and (optionally) have
+ * something parse their output.
+ */
+public final class AccurevLauncher {
+
+    /**
+     * Interface implemented by code that interprets the output of AccuRev
+     * commands.
+     * <p>
+     * Intended to separate out the running of commands from the actual parsing
+     * of their results in an attempt to reduce code duplication.
+     *
+     * @param <TResult>
+     *            The output of the parsing process.
+     * @param <TContext>
+     *            Context object that will be passed to the parser each time it
+     *            is called.
+     */
+    public interface ICmdOutputParser<TResult, TContext> {
+        /**
+         * Parses the command's output.
+         *
+         * @param cmdOutput
+         *            The stream that contains the output of the command.
+         * @param context
+         *            Context passed in when the command was run.
+         * @return The result of the parsing.
+         * @throws UnhandledAccurevCommandOutput
+         *             if the command output was invalid.
+         */
+        TResult parse(InputStream cmdOutput, TContext context) throws UnhandledAccurevCommandOutput, IOException;
+    }
+
+    /**
+     * Interface implemented by code that interprets the output of AccuRev
+     * commands.
+     * <p>
+     * Intended to separate out the running of commands from the actual parsing
+     * of their results in an attempt to reduce code duplication.
+     *
+     * @param <TResult>
+     *            The output of the parsing process.
+     * @param <TContext>
+     *            Context object that will be passed to the parser each time it
+     *            is called.
+     */
+    public interface ICmdOutputXmlParser<TResult, TContext> {
+        /**
+         * Parses the command's output.
+         *
+         * @param parser
+         *            The {@link XmlPullParser} that contains the output of the
+         *            command.
+         * @param context
+         *            Context passed in when the command was run.
+         * @return The result of the parsing.
+         * @throws UnhandledAccurevCommandOutput
+         *             if the command output was invalid.
+         */
+        TResult parse(XmlPullParser parser, TContext context) throws UnhandledAccurevCommandOutput, IOException,
+                XmlPullParserException;
+    }
+
+    /**
+     * Exception that can be throw if the AccuRev command's output cannot be
+     * parsed or is otherwise invalid.
+     */
+    public static final class UnhandledAccurevCommandOutput extends Exception {
+        public UnhandledAccurevCommandOutput(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public UnhandledAccurevCommandOutput(String message) {
+            super(message);
+        }
+
+        public UnhandledAccurevCommandOutput(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    /**
+     * Runs a command and returns <code>true</code> if it passed,
+     * <code>false</code> if it failed, and logs the errors.
+     *
+     * @param humanReadableCommandName
+     *            Human-readable text saying what this command is. This appears
+     *            in the logs if there is a failure.
+     * @param launcher
+     *            Means of executing the command.
+     * @param machineReadableCommand
+     *            The command to be executed.
+     * @param masksOrNull
+     *            Argument for {@link ProcStarter#masks(boolean...)}, or
+     *            <code>null</code> if not required.
+     * @param synchronizationLockObjectOrNull
+     *            The {@link Lock} object to be used to prevent concurrent
+     *            execution on the same machine, or <code>null</code> if no
+     *            synchronization is required.
+     * @param environmentVariables
+     *            The environment variables to be passed to the command.
+     * @param directoryToRunCommandFrom
+     *            The direction that the command should be run in.
+     * @param listenerToLogFailuresTo
+     *            One possible place to log failures, or <code>null</code>.
+     * @param loggerToLogFailuresTo
+     *            Another place to log failures, or <code>null</code>.
+     * @param optionalFlagToCopyAllOutputToTaskListener
+     *            Optional: If present and <code>true</code>, all command output
+     *            will also be copied to the listener if the command is
+     *            successful.
+     * @return <code>true</code> if the command succeeded.
+     */
+    public static boolean runCommand(//
+            final String humanReadableCommandName, //
+            final Launcher launcher, //
+            final ArgumentListBuilder machineReadableCommand, //
+            final boolean[] masksOrNull, //
+            final Lock synchronizationLockObjectOrNull, //
+            final Map<String, String> environmentVariables, //
+            final FilePath directoryToRunCommandFrom, //
+            final TaskListener listenerToLogFailuresTo, //
+            final Logger loggerToLogFailuresTo, //
+            final boolean... optionalFlagToCopyAllOutputToTaskListener) {
+        final Boolean result;
+        final boolean shouldLogEverything = optionalFlagToCopyAllOutputToTaskListener != null
+                && optionalFlagToCopyAllOutputToTaskListener.length > 0 && optionalFlagToCopyAllOutputToTaskListener[0];
+        if (shouldLogEverything) {
+            result = runCommand(humanReadableCommandName, launcher, machineReadableCommand, masksOrNull,
+                    synchronizationLockObjectOrNull, environmentVariables, directoryToRunCommandFrom,
+                    listenerToLogFailuresTo, loggerToLogFailuresTo, new ParseOutputToStream(),
+                    listenerToLogFailuresTo.getLogger());
+        } else {
+            result = runCommand(humanReadableCommandName, launcher, machineReadableCommand, masksOrNull,
+                    synchronizationLockObjectOrNull, environmentVariables, directoryToRunCommandFrom,
+                    listenerToLogFailuresTo, loggerToLogFailuresTo, new ParseIgnoreOutput(), null);
+        }
+        return result == Boolean.TRUE;
+    }
+
+    /**
+     * As
+     * {@link #runCommand(String, Launcher, ArgumentListBuilder, boolean[], Lock, Map, FilePath, TaskListener, Logger, ICmdOutputParser, Object)}
+     * but uses an {@link ICmdOutputXmlParser} instead.
+     *
+     * @param xmlParserFactory
+     *            The {@link XmlPullParserFactory} to be used to create the
+     *            parser. If this is <code>null</code> then no command will be
+     *            executed and the function will return <code>null</code>
+     *            immediately.
+     * @return See above.
+     */
+    public static <TResult, TContext> TResult runCommand(//
+            final String humanReadableCommandName, //
+            final Launcher launcher, //
+            final ArgumentListBuilder machineReadableCommand, //
+            final boolean[] masksOrNull, //
+            final Lock synchronizationLockObjectOrNull, //
+            final Map<String, String> environmentVariables, //
+            final FilePath directoryToRunCommandFrom, //
+            final TaskListener listenerToLogFailuresTo, //
+            final Logger loggerToLogFailuresTo, //
+            final XmlPullParserFactory xmlParserFactory, //
+            final ICmdOutputXmlParser<TResult, TContext> commandOutputParser, //
+            final TContext commandOutputParserContext) {
+        return runCommand(humanReadableCommandName, launcher, machineReadableCommand, masksOrNull,
+                synchronizationLockObjectOrNull, environmentVariables, directoryToRunCommandFrom,
+                listenerToLogFailuresTo, loggerToLogFailuresTo, new ICmdOutputParser<TResult, TContext>() {
+                    public TResult parse(InputStream cmdOutput, TContext context) throws UnhandledAccurevCommandOutput,
+                            IOException {
+                        final InputStreamReader readableXmlStream = new InputStreamReader(cmdOutput);
+                        XmlPullParser parser = null;
+                        try {
+                            parser = xmlParserFactory.newPullParser();
+                            parser.setInput(readableXmlStream);
+                            final TResult result = commandOutputParser.parse(parser, context);
+                            parser.setInput(null);
+                            parser = null;
+                            return result;
+                        } catch (XmlPullParserException ex) {
+                            logCommandException(machineReadableCommand, directoryToRunCommandFrom,
+                                    humanReadableCommandName, ex, loggerToLogFailuresTo, listenerToLogFailuresTo);
+                            return null;
+                        } finally {
+                            if (parser != null) {
+                                try {
+                                    parser.setInput(null);
+                                } catch (XmlPullParserException ex) {
+                                    logCommandException(machineReadableCommand, directoryToRunCommandFrom,
+                                            humanReadableCommandName, ex, loggerToLogFailuresTo,
+                                            listenerToLogFailuresTo);
+                                }
+                                readableXmlStream.close();
+                            }
+                        }
+                    }
+                }, commandOutputParserContext);
+    }
+
+    /**
+     * Runs a command a parses the output, returning the result of parsing that
+     * output. Returns <code>null</code> if the command failed or if parsing
+     * failed. Failures are logged.
+     *
+     * @param <TResult>
+     *            The type of the result returned by the parser.
+     * @param <TContext>
+     *            The type of data to be passed to the parser. Can be
+     *            {@link Void} if no result is needed.
+     * @param humanReadableCommandName
+     *            Human-readable text saying what this command is. This appears
+     *            in the logs if there is a failure.
+     * @param launcher
+     *            Means of executing the command.
+     * @param machineReadableCommand
+     *            The command to be executed.
+     * @param masksOrNull
+     *            Argument for {@link ProcStarter#masks(boolean...)}, or
+     *            <code>null</code> if not required.
+     * @param synchronizationLockObjectOrNull
+     *            The {@link Lock} object to be used to prevent concurrent
+     *            execution on the same machine, or <code>null</code> if no
+     *            synchronization is required.
+     * @param environmentVariables
+     *            The environment variables to be passed to the command.
+     * @param directoryToRunCommandFrom
+     *            The direction that the command should be run in.
+     * @param listenerToLogFailuresTo
+     *            One possible place to log failures, or <code>null</code>.
+     * @param loggerToLogFailuresTo
+     *            Another place to log failures, or <code>null</code>.
+     * @param commandOutputParser
+     *            The code that will parse the command's output (if the command
+     *            succeeds).
+     * @param commandOutputParserContext
+     *            Data to be passed to the parser.
+     * @return The data returned by the {@link ICmdOutputParser}, or
+     *         <code>null</code> if an error occurred.
+     */
+    public static <TResult, TContext> TResult runCommand(//
+            final String humanReadableCommandName, //
+            final Launcher launcher, //
+            final ArgumentListBuilder machineReadableCommand, //
+            final boolean[] masksOrNull, //
+            final Lock synchronizationLockObjectOrNull, //
+            final Map<String, String> environmentVariables, //
+            final FilePath directoryToRunCommandFrom, //
+            final TaskListener listenerToLogFailuresTo, //
+            final Logger loggerToLogFailuresTo, //
+            final ICmdOutputParser<TResult, TContext> commandOutputParser, //
+            final TContext commandOutputParserContext) {
+        final ByteArrayStream stdout = new ByteArrayStream();
+        final ByteArrayStream stderr = new ByteArrayStream();
+        try {
+            final OutputStream stdoutStream = stdout.getOutput();
+            final OutputStream stderrStream = stderr.getOutput();
+            final ProcStarter starter = createProcess(launcher, machineReadableCommand, masksOrNull,
+                    environmentVariables, directoryToRunCommandFrom, stdoutStream, stderrStream);
+            logCommandExecution(machineReadableCommand, directoryToRunCommandFrom, loggerToLogFailuresTo,
+                    listenerToLogFailuresTo);
+            try {
+                final int commandExitCode = runCommandToCompletion(starter, synchronizationLockObjectOrNull);
+                final InputStream outputFromCommand = stdout.getInput();
+                final InputStream errorFromCommand = stderr.getInput();
+                if (commandExitCode != 0) {
+                    logCommandFailure(machineReadableCommand, directoryToRunCommandFrom, humanReadableCommandName,
+                            commandExitCode, outputFromCommand, errorFromCommand, loggerToLogFailuresTo, listenerToLogFailuresTo);
+                    return null;
+                }
+                final TResult parsedResult = commandOutputParser.parse(outputFromCommand, commandOutputParserContext);
+                return parsedResult;
+            } catch (Exception ex) {
+                logCommandException(machineReadableCommand, directoryToRunCommandFrom, humanReadableCommandName, ex,
+                        loggerToLogFailuresTo, listenerToLogFailuresTo);
+                return null;
+            }
+        } finally {
+            try {
+                stdout.close();
+                stderr.close();
+            } catch (IOException ex) {
+                logCommandException(machineReadableCommand, directoryToRunCommandFrom, humanReadableCommandName, ex,
+                        loggerToLogFailuresTo, listenerToLogFailuresTo);
+            }
+        }
+    }
+
+    private static Integer runCommandToCompletion(//
+            final ProcStarter starter, //
+            final Lock synchronizationLockObjectOrNull) throws IOException, InterruptedException {
+        try {
+            if (synchronizationLockObjectOrNull != null) {
+                synchronizationLockObjectOrNull.lock();
+            }
+            final int commandExitCode = starter.join();
+            return Integer.valueOf(commandExitCode);
+        } finally {
+            if (synchronizationLockObjectOrNull != null) {
+                synchronizationLockObjectOrNull.unlock();
+            }
+        }
+    }
+
+    private static ProcStarter createProcess(//
+            final Launcher launcher, //
+            final ArgumentListBuilder machineReadableCommand, //
+            final boolean[] masksOrNull, //
+            final Map<String, String> environmentVariables, //
+            final FilePath directoryToRunCommandFrom, //
+            final OutputStream stdoutStream, //
+            final OutputStream stderrStream) {
+        ProcStarter starter = launcher.launch().cmds(machineReadableCommand);
+        if (masksOrNull != null) {
+            starter = starter.masks(masksOrNull);
+        }
+        starter = starter.envs(environmentVariables);
+        starter = starter.stdout(stdoutStream).stderr(stderrStream);
+        starter = starter.pwd(directoryToRunCommandFrom);
+        return starter;
+    }
+
+    private static void logCommandFailure(//
+            final ArgumentListBuilder command, //
+            final FilePath directoryToRunCommandFrom, //
+            final String commandDescription, //
+            final int commandExitCode, //
+            final InputStream commandStdoutOrNull, //
+            final InputStream commandStderrOrNull, //
+            final Logger loggerToLogFailuresTo, //
+            final TaskListener taskListener) {
+        final String msg = commandDescription + " (" + command.toStringWithQuote() + ")" + " failed with exit code "
+                + commandExitCode;
+        String stderr = null;
+        try {
+            stderr = getCommandErrorOutput(commandStdoutOrNull, commandStderrOrNull);
+        } catch (IOException ex) {
+            logCommandException(command, directoryToRunCommandFrom, commandDescription, ex, loggerToLogFailuresTo,
+                    taskListener);
+        }
+        if (loggerToLogFailuresTo != null
+                && (loggerToLogFailuresTo.isLoggable(Level.WARNING) || loggerToLogFailuresTo.isLoggable(Level.INFO))) {
+            final String hostname = getRemoteHostname(directoryToRunCommandFrom);
+            loggerToLogFailuresTo.warning(hostname + ": " + msg);
+            if (stderr != null) {
+                loggerToLogFailuresTo.info(hostname + ": " + stderr);
+            }
+        }
+        if (taskListener != null) {
+            if (stderr != null) {
+                taskListener.fatalError(stderr);
+            }
+            taskListener.fatalError(msg);
+        }
+    }
+
+    private static String getCommandErrorOutput(final InputStream commandStdoutOrNull,
+            final InputStream commandStderrOrNull) throws IOException {
+        final Integer maxNumberOfStderrLines = Integer.valueOf(10);
+        final Integer maxNumberOfStdoutLines = Integer.valueOf(5);
+        final String newLine = (String) System.getProperty("line.separator");
+        final ParseLastFewLines tailParser = new ParseLastFewLines();
+        final StringBuilder outputText = new StringBuilder();
+        if (commandStdoutOrNull != null) {
+            final List<String> stdoutLines = tailParser.parse(commandStdoutOrNull, maxNumberOfStdoutLines);
+            for (final String line : stdoutLines) {
+                if (outputText.length() > 0) {
+                    outputText.append(newLine);
+                }
+                outputText.append(line);
+            }
+        }
+        if (commandStderrOrNull != null) {
+            final List<String> stderrLines = tailParser.parse(commandStderrOrNull, maxNumberOfStderrLines);
+            for (final String line : stderrLines) {
+                if (outputText.length() > 0) {
+                    outputText.append(newLine);
+                }
+                outputText.append(line);
+            }
+        }
+        if (outputText.length() > 0) {
+            return outputText.toString();
+        } else {
+            return null;
+        }
+    }
+
+    private static void logCommandException(//
+            final ArgumentListBuilder command, //
+            final FilePath directoryToRunCommandFrom, //
+            final String commandDescription, //
+            final Throwable exception, //
+            final Logger loggerToLogFailuresTo, //
+            final TaskListener taskListener) {
+        final String hostname = getRemoteHostname(directoryToRunCommandFrom);
+        final String msg = hostname + ": " + commandDescription + " (" + command.toStringWithQuote() + ")"
+                + " failed with " + exception.toString();
+        logException(msg, exception, loggerToLogFailuresTo, taskListener);
+    }
+
+    static void logException(//
+            final String summary, //
+            final Throwable exception, //
+            final Logger logger, //
+            final TaskListener taskListener) {
+        if (logger != null) {
+            // TODO: Log the machine name to the Logger as well.
+            logger.log(Level.SEVERE, exception.getMessage(), exception);
+        }
+        if (taskListener != null) {
+            taskListener.fatalError(summary);
+            exception.printStackTrace(taskListener.getLogger());
+        }
+    }
+
+    private static void logCommandExecution(//
+            final ArgumentListBuilder command, //
+            final FilePath directoryToRunCommandFrom, //
+            final Logger loggerToLogFailuresTo, //
+            final TaskListener taskListener) {
+        if (loggerToLogFailuresTo != null && loggerToLogFailuresTo.isLoggable(Level.INFO)) {
+            final String hostname = getRemoteHostname(directoryToRunCommandFrom);
+            final String msg = hostname + ": " + command.toStringWithQuote();
+            loggerToLogFailuresTo.log(Level.INFO, msg);
+        }
+    }
+
+    private static String getRemoteHostname(final FilePath directoryToRunCommandFrom) {
+        try {
+            final RemoteWorkspaceDetails act = directoryToRunCommandFrom.act(new DetermineRemoteHostname("."));
+            final String hostName = act.getHostName();
+            return hostName;
+        } catch (UnknownHostException e) {
+            return e.toString();
+        } catch (IOException e) {
+            return e.toString();
+        } catch (InterruptedException e) {
+            return e.toString();
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/AccurevTransaction.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevTransaction.java
@@ -122,4 +122,22 @@ public final class AccurevTransaction extends ChangeLogSet.Entry {
     public void setId(int id) {
         this.id = id;
     }
+
+    private static final String FIELD_SEPARATOR = ", ";
+    private static final String EQ = "=";
+
+    @Override
+    public String toString() {
+        return '[' + //
+                "id" + EQ + id + //
+                FIELD_SEPARATOR + //
+                "date" + EQ + date + //
+                FIELD_SEPARATOR + //
+                "author" + EQ + author + //
+                FIELD_SEPARATOR + //
+                "action" + EQ + action + //
+                FIELD_SEPARATOR + //
+                "msg" + EQ + (msg == null ? "" : msg) + //
+                ']';
+    }
 }

--- a/src/main/java/hudson/plugins/accurev/ByteArrayStream.java
+++ b/src/main/java/hudson/plugins/accurev/ByteArrayStream.java
@@ -1,0 +1,53 @@
+package hudson.plugins.accurev;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Simple class to capture the output of something, and then allow that output
+ * to be read.
+ */
+public class ByteArrayStream implements Closeable {
+    private static final class Output extends ByteArrayOutputStream {
+        /**
+         * Returns an {@link InputStream} of our data without copying the data.
+         */
+        InputStream toInputStream() {
+            return new ByteArrayInputStream(super.buf, 0, super.count);
+        }
+    }
+
+    private final Output mOutputStream = new Output();
+
+    /**
+     * Gets the {@link ByteArrayOutputStream} to which data can be written.
+     *
+     * @return See above.
+     */
+    ByteArrayOutputStream getOutput() {
+        return mOutputStream;
+    }
+
+    /**
+     * Gets an {@link InputStream} that'll contain all the data that was written
+     * to {@link #getOutput()} thus far.
+     * <p>
+     * Note that it does NOT read any data written after this method completes
+     * and it is NOT thread-safe (if data is being written to when this method
+     * gets called, behaviour is undefined).
+     *
+     * @return See above.
+     */
+    InputStream getInput() {
+        return mOutputStream.toInputStream();
+    }
+
+    @Override
+    public void close() throws IOException {
+        mOutputStream.reset();
+        mOutputStream.close();
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/DetermineRemoteHostname.java
+++ b/src/main/java/hudson/plugins/accurev/DetermineRemoteHostname.java
@@ -1,0 +1,33 @@
+package hudson.plugins.accurev;
+
+import hudson.remoting.Callable;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+class DetermineRemoteHostname implements Callable<RemoteWorkspaceDetails, UnknownHostException> {
+
+    private final String path;
+
+    public DetermineRemoteHostname(String path) {
+        this.path = path;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public RemoteWorkspaceDetails call() throws UnknownHostException {
+        InetAddress addr = InetAddress.getLocalHost();
+        File f = new File(path);
+        String path;
+        try {
+            path = f.getCanonicalPath();
+        } catch (IOException e) {
+            path = f.getAbsolutePath();
+        }
+
+        return new RemoteWorkspaceDetails(addr.getCanonicalHostName(), path, File.separator);
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/FindAccurevClientExe.java
+++ b/src/main/java/hudson/plugins/accurev/FindAccurevClientExe.java
@@ -1,0 +1,39 @@
+package hudson.plugins.accurev;
+
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+
+import java.io.File;
+import java.io.IOException;
+
+final class FindAccurevClientExe implements FilePath.FileCallable<String> {
+
+    private final AccurevSCM.AccurevServer server;
+
+    public FindAccurevClientExe(AccurevSCM.AccurevServer server) {
+        this.server = server;
+    }
+
+    private static String getExistingPath(String[] paths, String fallback) {
+        for (final String path : paths) {
+            if (new File(path).exists()) {
+                return path;
+            }
+        }
+        // just hope it's on the environment's path
+        return fallback;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String invoke(File f, VirtualChannel channel) throws IOException {
+        if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
+            // we are running on windows
+            return getExistingPath(server.getWinCmdLocations(), "accurev.exe");
+        } else {
+            // we are running on *nix
+            return getExistingPath(server.getNixCmdLocations(), "accurev");
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParseChangeLog.java
+++ b/src/main/java/hudson/plugins/accurev/ParseChangeLog.java
@@ -1,0 +1,126 @@
+package hudson.plugins.accurev;
+
+import hudson.model.AbstractBuild;
+import hudson.scm.ChangeLogParser;
+import hudson.scm.ChangeLogSet;
+import hudson.util.IOException2;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.xml.sax.SAXException;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+/**
+ * Parses a change log that was recorded by {@link ParseOutputToFile}.
+ */
+class ParseChangeLog extends ChangeLogParser {
+    private static final Logger logger = Logger.getLogger(AccurevSCM.class.getName());
+    private static final long MILLIS_PER_SECOND = 1000L;
+
+    /**
+     * {@inheritDoc}
+     */
+    public ChangeLogSet<AccurevTransaction> parse(AbstractBuild build, File changelogFile)//
+            throws IOException, SAXException {
+        List<AccurevTransaction> transactions = null;
+        try {
+            XmlPullParser parser = XmlParserFactory.newParser();
+            FileReader fis = null;
+            BufferedReader bis = null;
+            try {
+                fis = new FileReader(changelogFile);
+                bis = new BufferedReader(fis);
+                parser.setInput(bis);
+                transactions = parseTransactions(parser);
+            } finally {
+                if (bis != null) {
+                    bis.close();
+                }
+                if (fis != null) {
+                    fis.close();
+                }
+                if (parser != null) {
+                    parser.setInput(null);
+                }
+            }
+        } catch (XmlPullParserException e) {
+            throw new IOException2(e);
+        }
+
+        logger.info("transactions size = " + transactions.size());
+        return new AccurevChangeLogSet(build, transactions);
+    }
+
+    private List<AccurevTransaction> parseTransactions(XmlPullParser parser) throws IOException, XmlPullParserException {
+        List<AccurevTransaction> transactions = new ArrayList<AccurevTransaction>();
+        AccurevTransaction currentTransaction = null;
+        boolean inComment = false;
+        while (true) {
+            switch (parser.next()) {
+            case XmlPullParser.START_DOCUMENT:
+                break;
+            case XmlPullParser.END_DOCUMENT:
+                return transactions;
+            case XmlPullParser.START_TAG:
+                final String tagName = parser.getName();
+                inComment = "comment".equalsIgnoreCase(tagName);
+                if ("transaction".equalsIgnoreCase(tagName)) {
+                    currentTransaction = new AccurevTransaction();
+                    transactions.add(currentTransaction);
+                    currentTransaction.setRevision(parser.getAttributeValue("", "id"));
+                    currentTransaction.setUser(parser.getAttributeValue("", "user"));
+                    currentTransaction
+                            .setDate(ParseChangeLog.convertAccurevTimestamp(parser.getAttributeValue("", "time")));
+                    currentTransaction.setAction(parser.getAttributeValue("", "type"));
+                } else if ("version".equalsIgnoreCase(tagName) && currentTransaction != null) {
+                    String path = parser.getAttributeValue("", "path");
+                    if (path != null) {
+                        path = path.replace("\\", "/");
+                        if (path.startsWith("/./")) {
+                            path = path.substring(3);
+                        }
+                    }
+                    currentTransaction.addAffectedPath(path);
+                }
+                break;
+            case XmlPullParser.END_TAG:
+                inComment = false;
+                break;
+            case XmlPullParser.TEXT:
+                if (inComment && currentTransaction != null) {
+                    currentTransaction.setMsg(parser.getText());
+                }
+                break;
+            }
+        }
+    }
+
+    /**
+     * Converts an Accurev timestamp into a {@link Date}
+     *
+     * @param transactionTime
+     *            The accurev timestamp.
+     *
+     * @return A {@link Date} set to the time for the accurev timestamp.
+     */
+    static Date convertAccurevTimestamp(String transactionTime) {
+        if (transactionTime == null) {
+            return null;
+        }
+        try {
+            final long time = Long.parseLong(transactionTime);
+            final long date = time * MILLIS_PER_SECOND;
+            return new Date(date);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParseHistory.java
+++ b/src/main/java/hudson/plugins/accurev/ParseHistory.java
@@ -1,0 +1,35 @@
+package hudson.plugins.accurev;
+
+import hudson.plugins.accurev.AccurevLauncher.ICmdOutputXmlParser;
+import hudson.plugins.accurev.AccurevLauncher.UnhandledAccurevCommandOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+final class ParseHistory implements ICmdOutputXmlParser<Boolean, List<AccurevTransaction>> {
+    public Boolean parse(XmlPullParser parser, List<AccurevTransaction> context) throws UnhandledAccurevCommandOutput,
+            IOException, XmlPullParserException {
+        AccurevTransaction resultTransaction = null;
+        while (parser.next() != XmlPullParser.END_DOCUMENT) {
+            if (parser.getEventType() == XmlPullParser.START_TAG) {
+                if (parser.getName().equalsIgnoreCase("transaction")) {
+                    resultTransaction = new AccurevTransaction();
+                    // parse transaction-values
+                    resultTransaction.setId((Integer.parseInt(parser.getAttributeValue("", "id"))));
+                    resultTransaction.setAction(parser.getAttributeValue("", "type"));
+                    resultTransaction.setDate(ParseChangeLog.convertAccurevTimestamp(parser.getAttributeValue("",
+                            "time")));
+                    resultTransaction.setUser(parser.getAttributeValue("", "user"));
+                } else if (parser.getName().equalsIgnoreCase("comment")) {
+                    // parse comments
+                    resultTransaction.setMsg(parser.nextText());
+                }
+            }
+        }
+        context.add(resultTransaction);
+        return Boolean.valueOf(resultTransaction != null);
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParseIgnoreOutput.java
+++ b/src/main/java/hudson/plugins/accurev/ParseIgnoreOutput.java
@@ -1,0 +1,11 @@
+package hudson.plugins.accurev;
+
+import hudson.plugins.accurev.AccurevLauncher.ICmdOutputParser;
+
+import java.io.InputStream;
+
+final class ParseIgnoreOutput implements ICmdOutputParser<Boolean, Void> {
+    public Boolean parse(InputStream cmdOutput, Void context) {
+        return Boolean.TRUE;
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParseInfoToLoginName.java
+++ b/src/main/java/hudson/plugins/accurev/ParseInfoToLoginName.java
@@ -1,0 +1,40 @@
+package hudson.plugins.accurev;
+
+import hudson.plugins.accurev.AccurevLauncher.ICmdOutputParser;
+import hudson.plugins.accurev.AccurevLauncher.UnhandledAccurevCommandOutput;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+final class ParseInfoToLoginName implements ICmdOutputParser<String, Void> {
+    public String parse(InputStream cmdOutput, Void context) throws UnhandledAccurevCommandOutput, IOException {
+        final String usernameHeading = "Principal:";
+        final String controlCharsOrSpaceRegex = "[ \\x00-\\x1F\\x7F]+";
+        final Reader stringReader = new InputStreamReader(cmdOutput);
+        final BufferedReader lineReader = new BufferedReader(stringReader);
+        String line;
+        try {
+            line = lineReader.readLine();
+            while (line != null) {
+                final String[] parts = line.split(controlCharsOrSpaceRegex);
+                for (int i = 0; i < parts.length; i++) {
+                    final String part = parts[i];
+                    if (usernameHeading.equals(part)) {
+                        if ((i + 1) < parts.length) {
+                            final String username = parts[i + 1];
+                            return username;
+                        }
+                    }
+                }
+                line = lineReader.readLine();
+            }
+        } finally {
+            lineReader.close();
+        }
+        throw new UnhandledAccurevCommandOutput("Output did not contain " + usernameHeading + " "
+                + controlCharsOrSpaceRegex + " <username>");
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParseLastFewLines.java
+++ b/src/main/java/hudson/plugins/accurev/ParseLastFewLines.java
@@ -1,0 +1,40 @@
+package hudson.plugins.accurev;
+
+import hudson.plugins.accurev.AccurevLauncher.ICmdOutputParser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Filters the output of any command and just returns the last few lines.
+ */
+final class ParseLastFewLines implements ICmdOutputParser<List<String>, Integer> {
+    public List<String> parse(InputStream cmdOutput, Integer numberOfLines) throws 
+            IOException {
+        final LinkedList<String> result = new LinkedList<String>();
+        final Reader stringReader = new InputStreamReader(cmdOutput);
+        final BufferedReader lineReader = new BufferedReader(stringReader);
+        int linesRemainingBeforeWeAreFull = numberOfLines.intValue();
+        String line;
+        try {
+            line = lineReader.readLine();
+            while (line != null) {
+                result.add(line);
+                if (linesRemainingBeforeWeAreFull > 0) {
+                    linesRemainingBeforeWeAreFull--;
+                } else {
+                    result.removeFirst();
+                }
+                line = lineReader.readLine();
+            }
+        } finally {
+            lineReader.close();
+        }
+        return result;
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParseLsRules.java
+++ b/src/main/java/hudson/plugins/accurev/ParseLsRules.java
@@ -1,0 +1,42 @@
+package hudson.plugins.accurev;
+
+import hudson.plugins.accurev.AccurevLauncher.ICmdOutputXmlParser;
+import hudson.plugins.accurev.AccurevLauncher.UnhandledAccurevCommandOutput;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+final class ParseLsRules implements ICmdOutputXmlParser<HashMap<String, String>, Void> {
+    public HashMap<String, String> parse(final XmlPullParser parser, final Void context)
+            throws UnhandledAccurevCommandOutput, IOException, XmlPullParserException {
+        // Parse the 'accurev lsrules' command, and build up the
+        // include/exclude rules map
+        final HashMap<String, String> locationToKindMap = new HashMap<String, String>();
+        // key: String location, val: String kind (incl / excl / incldo)
+        while (true) {
+            switch (parser.next()) {
+            case XmlPullParser.START_DOCUMENT:
+                break;
+            case XmlPullParser.START_TAG:
+                final String tagName = parser.getName();
+                if ("element".equalsIgnoreCase(tagName)) {
+                    String kind = parser.getAttributeValue("", "kind");
+                    String location = parser.getAttributeValue("", "location");
+                    if (location != null && kind != null) {
+                        locationToKindMap.put(location, kind);
+                    }
+                }
+                break;
+            case XmlPullParser.END_TAG:
+                break;
+            case XmlPullParser.TEXT:
+                break;
+            case XmlPullParser.END_DOCUMENT:
+                return locationToKindMap;
+            }
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParseOutputToFile.java
+++ b/src/main/java/hudson/plugins/accurev/ParseOutputToFile.java
@@ -1,0 +1,26 @@
+package hudson.plugins.accurev;
+
+import hudson.plugins.accurev.AccurevLauncher.ICmdOutputParser;
+import hudson.plugins.accurev.AccurevLauncher.UnhandledAccurevCommandOutput;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+final class ParseOutputToFile implements ICmdOutputParser<Boolean, File> {
+    public Boolean parse(InputStream cmdOutput, File fileToWriteTo) throws UnhandledAccurevCommandOutput, IOException {
+        final FileOutputStream os = new FileOutputStream(fileToWriteTo);
+        final byte[] buffer = new byte[4096];
+        try {
+            int bytesRead = cmdOutput.read(buffer);
+            while (bytesRead > 0) {
+                os.write(buffer, 0, bytesRead);
+                bytesRead = cmdOutput.read(buffer);
+            }
+        } finally {
+            os.close();
+        }
+        return Boolean.TRUE;
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParseOutputToStream.java
+++ b/src/main/java/hudson/plugins/accurev/ParseOutputToStream.java
@@ -1,0 +1,20 @@
+package hudson.plugins.accurev;
+
+import hudson.plugins.accurev.AccurevLauncher.UnhandledAccurevCommandOutput;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+final class ParseOutputToStream implements AccurevLauncher.ICmdOutputParser<Boolean, OutputStream> {
+    public Boolean parse(InputStream cmdOutput, OutputStream streamToCopyOutputTo)
+            throws UnhandledAccurevCommandOutput, IOException {
+        final byte[] buffer = new byte[4096];
+        int bytesRead = cmdOutput.read(buffer);
+        while (bytesRead > 0) {
+            streamToCopyOutputTo.write(buffer, 0, bytesRead);
+            bytesRead = cmdOutput.read(buffer);
+        }
+        return Boolean.TRUE;
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParsePopulate.java
+++ b/src/main/java/hudson/plugins/accurev/ParsePopulate.java
@@ -1,0 +1,53 @@
+package hudson.plugins.accurev;
+
+import hudson.plugins.accurev.AccurevLauncher.ICmdOutputParser;
+import hudson.plugins.accurev.AccurevLauncher.UnhandledAccurevCommandOutput;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+
+/**
+ * Filters the output of the populate command and just shows a summary of the
+ * output. Helps prevent build logs being clogged up with the checkout.
+ */
+final class ParsePopulate implements ICmdOutputParser<Boolean, OutputStream> {
+    public Boolean parse(InputStream cmdOutput, OutputStream streamToCopyOutputTo)
+            throws UnhandledAccurevCommandOutput, IOException {
+        final String lineStartDirectory = "Creating dir:";
+        final String lineStartElement = "Populating element";
+        int countOfDirectories = 0;
+        int countOfElements = 0;
+        final Reader stringReader = new InputStreamReader(cmdOutput);
+        final Writer stringWriter = new OutputStreamWriter(streamToCopyOutputTo);
+        final BufferedReader lineReader = new BufferedReader(stringReader);
+        final BufferedWriter lineWriter = new BufferedWriter(stringWriter);
+        String line;
+        try {
+            line = lineReader.readLine();
+            while (line != null) {
+                if (line.startsWith(lineStartElement)) {
+                    countOfElements++;
+                } else if (line.startsWith(lineStartDirectory)) {
+                    countOfDirectories++;
+                } else {
+                    lineWriter.write(line);
+                    lineWriter.newLine();
+                }
+                line = lineReader.readLine();
+            }
+            final String msg = "Populated " + countOfElements + " elements in " + countOfDirectories + " directories.";
+            streamToCopyOutputTo.write(msg.getBytes());
+        } finally {
+            lineReader.close();
+            lineWriter.flush();
+        }
+        return Boolean.TRUE;
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParseShowStreams.java
+++ b/src/main/java/hudson/plugins/accurev/ParseShowStreams.java
@@ -1,0 +1,75 @@
+package hudson.plugins.accurev;
+
+import hudson.plugins.accurev.AccurevLauncher.ICmdOutputXmlParser;
+import hudson.plugins.accurev.AccurevLauncher.UnhandledAccurevCommandOutput;
+import hudson.plugins.accurev.AccurevStream.StreamType;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+final class ParseShowStreams implements ICmdOutputXmlParser<Map<String, AccurevStream>, String> {
+    public Map<String, AccurevStream> parse(XmlPullParser parser, String depot) throws UnhandledAccurevCommandOutput,
+            IOException, XmlPullParserException {
+        final Map<String, AccurevStream> streams = new HashMap<String, AccurevStream>();
+        while (true) {
+            switch (parser.next()) {
+            case XmlPullParser.START_DOCUMENT:
+                break;
+            case XmlPullParser.END_DOCUMENT:
+                // build the tree
+                for (AccurevStream stream : streams.values()) {
+                    if (stream.getBasisName() != null) {
+                        stream.setParent(streams.get(stream.getBasisName()));
+                    }
+                }
+                return streams;
+            case XmlPullParser.START_TAG:
+                final String tagName = parser.getName();
+                if ("stream".equalsIgnoreCase(tagName)) {
+                    final String streamName = parser.getAttributeValue("", "name");
+                    final String streamNumberStr = parser.getAttributeValue("", "streamNumber");
+                    final String basisStreamName = parser.getAttributeValue("", "basis");
+                    final String basisStreamNumberStr = parser.getAttributeValue("", "basisStreamNumber");
+                    final String streamTypeStr = parser.getAttributeValue("", "type");
+                    final String streamIsDynamic = parser.getAttributeValue("", "isDynamic");
+                    final String streamTimeString = parser.getAttributeValue("", "time");
+                    final Date streamTime = streamTimeString == null ? null : ParseChangeLog
+                            .convertAccurevTimestamp(streamTimeString);
+                    final String streamStartTimeString = parser.getAttributeValue("", "startTime");
+                    final Date streamStartTime = streamTimeString == null ? null : ParseChangeLog
+                            .convertAccurevTimestamp(streamStartTimeString);
+                    try {
+                        final Long streamNumber = streamNumberStr == null ? null : Long.valueOf(streamNumberStr);
+                        final Long basisStreamNumber = basisStreamNumberStr == null ? null : Long
+                                .valueOf(basisStreamNumberStr);
+                        final StreamType streamType = AccurevStream.StreamType.parseStreamType(streamTypeStr);
+                        final boolean isDynamic = streamIsDynamic != null && Boolean.parseBoolean(streamIsDynamic);
+                        final AccurevStream stream = new AccurevStream(//
+                                streamName, //
+                                streamNumber, //
+                                depot, //
+                                basisStreamName, //
+                                basisStreamNumber, //
+                                isDynamic, //
+                                streamType, //
+                                streamTime, //
+                                streamStartTime);
+                        streams.put(streamName, stream);
+                    } catch (NumberFormatException e) {
+                        throw new UnhandledAccurevCommandOutput(e);
+                    }
+                }
+                break;
+            case XmlPullParser.END_TAG:
+                break;
+            case XmlPullParser.TEXT:
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParseShowWorkspaces.java
+++ b/src/main/java/hudson/plugins/accurev/ParseShowWorkspaces.java
@@ -1,0 +1,46 @@
+package hudson.plugins.accurev;
+
+import hudson.plugins.accurev.AccurevLauncher.ICmdOutputXmlParser;
+import hudson.plugins.accurev.AccurevLauncher.UnhandledAccurevCommandOutput;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+final class ParseShowWorkspaces implements ICmdOutputXmlParser<Map<String, AccurevWorkspace>, Void> {
+    public Map<String, AccurevWorkspace> parse(XmlPullParser parser, Void context)
+            throws UnhandledAccurevCommandOutput, IOException, XmlPullParserException {
+        final Map<String, AccurevWorkspace> workspaces = new HashMap<String, AccurevWorkspace>();
+        while (true) {
+            switch (parser.next()) {
+            case XmlPullParser.START_DOCUMENT:
+                break;
+            case XmlPullParser.END_DOCUMENT:
+                return workspaces;
+            case XmlPullParser.START_TAG:
+                final String tagName = parser.getName();
+                if ("Element".equalsIgnoreCase(tagName)) {
+                    final String name = parser.getAttributeValue("", "Name");
+                    final String storage = parser.getAttributeValue("", "Storage");
+                    final String host = parser.getAttributeValue("", "Host");
+                    final String streamNumber = parser.getAttributeValue("", "Stream");
+                    final String depot = parser.getAttributeValue("", "depot");
+                    try {
+                        final Long streamNumberOrNull = streamNumber == null ? null : Long.valueOf(streamNumber);
+                        workspaces.put(name, new AccurevWorkspace(depot, streamNumberOrNull, name, host, storage));
+                    } catch (NumberFormatException e) {
+                        throw new UnhandledAccurevCommandOutput(e);
+                    }
+                }
+                break;
+            case XmlPullParser.END_TAG:
+                break;
+            case XmlPullParser.TEXT:
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/ParseStatOverlaps.java
+++ b/src/main/java/hudson/plugins/accurev/ParseStatOverlaps.java
@@ -1,0 +1,43 @@
+package hudson.plugins.accurev;
+
+import hudson.plugins.accurev.AccurevLauncher.ICmdOutputXmlParser;
+import hudson.plugins.accurev.AccurevLauncher.UnhandledAccurevCommandOutput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+final class ParseStatOverlaps implements ICmdOutputXmlParser<List<String>, Void> {
+    public List<String> parse(XmlPullParser parser, Void context) throws UnhandledAccurevCommandOutput, IOException,
+            XmlPullParserException {
+        final List<String> overlaps = new ArrayList<String>();
+        while (true) {
+            switch (parser.next()) {
+            case XmlPullParser.START_DOCUMENT:
+                break;
+            case XmlPullParser.END_DOCUMENT:
+                // build the tree
+                return overlaps;
+            case XmlPullParser.START_TAG:
+                final String tagName = parser.getName();
+                if ("element".equalsIgnoreCase(tagName)) {
+                    final String filename = parser.getAttributeValue("", "location");
+                    final String dir = parser.getAttributeValue("", "dir"); // yes or no
+                    if ("no".equalsIgnoreCase(dir)) {
+                        overlaps.add(filename);
+                    } else {
+                        // don't add dirs to overlap list
+                    }
+                }
+                break;
+            case XmlPullParser.END_TAG:
+                break;
+            case XmlPullParser.TEXT:
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/PurgeWorkspaceContents.java
+++ b/src/main/java/hudson/plugins/accurev/PurgeWorkspaceContents.java
@@ -1,0 +1,32 @@
+package hudson.plugins.accurev;
+
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+
+import java.io.File;
+import java.io.IOException;
+
+final class PurgeWorkspaceContents implements FilePath.FileCallable<Boolean> {
+
+    private final TaskListener listener;
+
+    public PurgeWorkspaceContents(TaskListener listener) {
+        this.listener = listener;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Boolean invoke(File ws, VirtualChannel channel) throws IOException {
+        listener.getLogger().println("Purging workspace...");
+        System.runFinalization();
+        System.gc();
+        System.runFinalization();
+        // TODO: Retry delete - on Windows, it can fail claiming that the file is in use.
+        Util.deleteContentsRecursive(ws);
+        listener.getLogger().println("Workspace purged.");
+        return Boolean.TRUE;
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/PurgeWorkspaceOverlaps.java
+++ b/src/main/java/hudson/plugins/accurev/PurgeWorkspaceOverlaps.java
@@ -1,0 +1,35 @@
+package hudson.plugins.accurev;
+
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+final class PurgeWorkspaceOverlaps implements FilePath.FileCallable<Boolean> {
+
+    private final List<String> filelist;
+    private final TaskListener listener;
+
+    public PurgeWorkspaceOverlaps(TaskListener listener, List<String> filelist) {
+        this.filelist = filelist;
+        this.listener = listener;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Boolean invoke(File ws, VirtualChannel channel) throws IOException {
+        listener.getLogger().println("Purging overlaps...");
+        for (String filename : filelist) {
+            File toPurge = new File(ws, filename);
+            Util.deleteFile(toPurge);
+            listener.getLogger().println("... " + toPurge.getAbsolutePath());
+        }
+        listener.getLogger().println("Overlaps purged.");
+        return Boolean.TRUE;
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/RemoteWorkspaceDetails.java
+++ b/src/main/java/hudson/plugins/accurev/RemoteWorkspaceDetails.java
@@ -1,0 +1,43 @@
+package hudson.plugins.accurev;
+
+import java.io.Serializable;
+
+class RemoteWorkspaceDetails implements Serializable {
+
+    private final String hostName;
+    private final String path;
+    private final String fileSeparator;
+
+    public RemoteWorkspaceDetails(String hostName, String path, String fileSeparator) {
+        this.hostName = hostName;
+        this.path = path;
+        this.fileSeparator = fileSeparator;
+    }
+
+    /**
+     * Getter for property 'hostName'.
+     *
+     * @return Value for property 'hostName'.
+     */
+    public String getHostName() {
+        return hostName;
+    }
+
+    /**
+     * Getter for property 'path'.
+     *
+     * @return Value for property 'path'.
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * Getter for property 'fileSeparator'.
+     *
+     * @return Value for property 'fileSeparator'.
+     */
+    public String getFileSeparator() {
+        return fileSeparator;
+    }
+}

--- a/src/main/java/hudson/plugins/accurev/XmlParserFactory.java
+++ b/src/main/java/hudson/plugins/accurev/XmlParserFactory.java
@@ -1,0 +1,61 @@
+package hudson.plugins.accurev;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.logging.Logger;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+import org.xmlpull.v1.XmlPullParserFactory;
+
+/**
+ * Utility class that provides {@link XmlPullParserFactory}s.
+ */
+public class XmlParserFactory {
+    private static final Logger logger = Logger.getLogger(AccurevSCM.class.getName());
+
+    /**
+     * Gets a new {@link XmlPullParser} configured for parsing Accurev XML
+     * files.
+     *
+     * @return a new {@link XmlPullParser} configured for parsing Accurev XML
+     *         files.
+     *
+     * @throws XmlPullParserException
+     *             when things go wrong/
+     */
+    static XmlPullParser newParser() throws XmlPullParserException {
+        return getFactory().newPullParser();
+    }
+
+    private static final Map<Object, XmlPullParserFactory> PARSER_FACTORY_CACHE = new WeakHashMap<Object, XmlPullParserFactory>(
+            1);
+
+    /**
+     * Gets a new {@link XmlPullParserFactory} configured for parsing Accurev
+     * XML files.
+     *
+     * @return a new {@link XmlPullParserFactory} configured for parsing Accurev
+     *         XML files, or <code>null</code> if things go wrong.
+     */
+    static XmlPullParserFactory getFactory() {
+        synchronized (PARSER_FACTORY_CACHE) {
+            final XmlPullParserFactory existingFactory = PARSER_FACTORY_CACHE.get(XmlPullParserFactory.class);
+            if (existingFactory != null) {
+                return existingFactory;
+            }
+            XmlPullParserFactory newFactory;
+            try {
+                newFactory = XmlPullParserFactory.newInstance();
+            } catch (XmlPullParserException ex) {
+                AccurevLauncher.logException("Unable to create new " + XmlPullParserFactory.class.getSimpleName(), ex,
+                        logger, null);
+                return null;
+            }
+            newFactory.setNamespaceAware(false);
+            newFactory.setValidating(false);
+            PARSER_FACTORY_CACHE.put(XmlPullParserFactory.class, newFactory);
+            return newFactory;
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
@@ -50,6 +50,9 @@
                 <f:textbox name="accurev.snapshotNameFormat" value="${scm.snapshotNameFormat}"/>
             </f:entry>
         </f:optionalBlock>
+        <f:entry title="Ignore parent changes" help="/plugin/accurev/help/project/ignore-stream-parent.html">
+            <f:checkbox name="accurev.ignoreStreamParent" checked="${scm.ignoreStreamParent}"/>
+        </f:entry>
     </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/global.jelly
@@ -8,7 +8,6 @@
                         <input class="setting-input" type="text"
                                name="server.name" value="${server.name}"/>
                     </f:entry>
-
                     <f:entry title="Host">
                         <input class="setting-input" type="text"
                                name="server.host" value="${server.host}"/>
@@ -40,13 +39,18 @@
                         <f:entry title="Use Non-expiring Login" help="/plugin/accurev/help/use-nonexpiring-login.html">
                             <f:checkbox name="server.useNonexpiringLogin" checked="${server.useNonexpiringLogin}" default="false" />
                         </f:entry>
+                        <f:entry title="Show one stream at a time" help="/plugin/accurev/help/use-restricted-show-streams.html">
+                            <f:checkbox name="server.useRestrictedShowStreams" checked="${server.useRestrictedShowStreams}" default="false" />
+                        </f:entry>
                     </f:advanced>
-
                 </table>
                 <div align="right">
                     <f:repeatableDeleteButton/>
                 </div>
             </f:repeatable>
+        </f:entry>
+        <f:entry title="Poll on master" help="/plugin/accurev/help/poll-on-master.html">
+            <f:checkbox name="descriptor.pollOnMaster" checked="${descriptor.pollOnMaster}" default="false" />
         </f:entry>
     </f:section>
 </j:jelly>

--- a/src/main/webapp/help/poll-on-master.html
+++ b/src/main/webapp/help/poll-on-master.html
@@ -1,0 +1,27 @@
+<div>
+	<p>
+		If checked then:
+		<ul>
+			<li>
+				The plugin will (only) run accurev polling operations
+				on the master node.
+			</li>
+			<li>
+				Builds will no longer be triggered just because the
+				slave that did the last build goes offline.
+			</li>
+		</ul>
+		If not checked then:
+		<ul>
+			<li>
+				Polling operations will be run on the slave that did the last build.
+			</li>
+			<li>
+				If that slave does offline, a new build will be triggered,
+				whether or not there are changes.
+			</li>
+		</ul>
+		<br />
+		Do NOT enable this unless accurev is installed on the master node.
+	</p>
+</div>

--- a/src/main/webapp/help/project/ignore-stream-parent.html
+++ b/src/main/webapp/help/project/ignore-stream-parent.html
@@ -1,0 +1,11 @@
+<div>
+	<p>
+		If checked then, when checking for changes etc, the plugin will ignore
+		the possibility that there have been changes in the parent stream that
+		affect the contents of the stream being polled.
+		<br />
+		<br />
+		This is purely a runtime optimisation for when accurev is being used
+		as a normal VCS and not taking advantage of its stream inheritance.
+	</p>
+</div>

--- a/src/main/webapp/help/use-restricted-show-streams.html
+++ b/src/main/webapp/help/use-restricted-show-streams.html
@@ -1,0 +1,20 @@
+<div>
+	<p>
+		If checked then, when issuing an "accurev show ... streams"
+		command, the plugin will use the "-s <i>streamname</i>" option to
+		restrict the output to just the stream in question, look at the result
+		to determine the basis stream and then repeat for that
+		stream's parent etc until the full ancestry is obtained. If not checked,
+		when the plugin needs to know about the stream it is using, it'll simply
+		get all of the streams from the server (which can involve a lot of
+		data). <br />
+		<br />
+		This is best enabled on accurev servers with a lot of streams,
+		snapshots, workspaces etc.<br />
+		When there are relatively few streams and snapshots aren't used, it is
+		typically quicker to get all the streams that the server knows about in
+		one single command. When there are a lot of them, it's often faster to
+		send multiple commands that get the stream you want, and then its parent,
+		and its parent etc until you reach the top of the chain.
+	</p>
+</div>

--- a/src/main/webapp/help/validTransactionTypes.html
+++ b/src/main/webapp/help/validTransactionTypes.html
@@ -23,5 +23,8 @@
             <li>purge - </li>
             <li>dispatch - </li>
         </ul>
+        <br />
+        Note that if you are only ever building the contents of streams, then
+        polling for "promote" transactions is likely to suffice on its own.
     </p>
 </div>


### PR DESCRIPTION
Bugfix: JENKINS-10754
Enhancement: JENKINS-10637 (mitigates 10719).
New feature: JENKINS-10754 (mitigates 10719):
- New feature: Ignore parent stream - can now tell a project to ignore changes made in the basis stream of the actual stream being built.  This can signficantly reduce the time the plugin takes talking to the accurev server.
- New feature: Get streams singly - more of an accurev client workaround really; the plugin used to call the server and get "the streams" which included absolutely everything under the sun, and this turns into many megabytes of data, every poll and every build.  This server setting says to get just the streams we care about (our stream, our parent stream etc), albeit at the cost of potentially making more than one call to the server.
  Enhancement: Logging improved, which should make debugging accurev client failures a little easier.
  Enhancement: Now weakly caches the XmlPullParserFactory.
  Refactor: Extracted out code that runs the accurev client command into its own class, reducing duplicated code and making parsing of command-output more consistent.
  Refactor: Split out many of AccurevSCM's inner classes into their own files in an attempt to make the main class more maintainable.
