### PR TITLE
Null related fixes

### DIFF
--- a/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
@@ -381,7 +381,7 @@ public final class AccurevLauncher {
     private static String maskPasswordFromLogOutput(String inputCommand) {
     	String sanitized = inputCommand;
     	if (sanitized != null) {
-    		if (sanitized.contains("login")) {
+    		if (sanitized.contains(" login ")) {
     			sanitized = sanitized.replaceAll("[^\\s]+$", "***********");  //last word of phrase
     		}
     	}

--- a/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
@@ -428,7 +428,7 @@ public final class AccurevLauncher {
             final Logger loggerToLogFailuresTo, //
             final TaskListener taskListener) {
         final String hostname = getRemoteHostname(directoryToRunCommandFrom);
-        final String msg = hostname + ": " + commandDescription + " (" + command.toStringWithQuote() + ")"
+        final String msg = hostname + ": " + commandDescription + " (" + maskPasswordFromLogOutput ( command.toStringWithQuote() ) + ")"
                 + " failed with " + exception.toString();
         logException(msg, exception, loggerToLogFailuresTo, taskListener);
     }
@@ -455,7 +455,7 @@ public final class AccurevLauncher {
             final TaskListener taskListener) {
         if (loggerToLogFailuresTo != null && loggerToLogFailuresTo.isLoggable(Level.INFO)) {
             final String hostname = getRemoteHostname(directoryToRunCommandFrom);
-            final String msg = hostname + ": " + command.toStringWithQuote();
+            final String msg = hostname + ": " + maskPasswordFromLogOutput ( command.toStringWithQuote() );
             loggerToLogFailuresTo.log(Level.INFO, msg);
         }
     }

--- a/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
@@ -352,8 +352,8 @@ public final class AccurevLauncher {
             final InputStream commandStderrOrNull, //
             final Logger loggerToLogFailuresTo, //
             final TaskListener taskListener) {
-        final String msg = commandDescription + " (" + command.toStringWithQuote() + ")" + " failed with exit code "
-                + commandExitCode;
+        final String msg = commandDescription + " (" + maskPasswordFromLogOutput( command.toStringWithQuote() ) + ")" 
+            + " failed with exit code " + commandExitCode;
         String stderr = null;
         try {
             stderr = getCommandErrorOutput(commandStdoutOrNull, commandStderrOrNull);
@@ -375,6 +375,17 @@ public final class AccurevLauncher {
             }
             taskListener.fatalError(msg);
         }
+    }
+    
+    /** AccurevSCM builds login command with username/pass as last pair of params */
+    private static String maskPasswordFromLogOutput(String inputCommand) {
+    	String sanitized = inputCommand;
+    	if (sanitized != null) {
+    		if (sanitized.contains("login")) {
+    			sanitized = sanitized.replaceAll("[^\\s]+$", "***********");  //last word of phrase
+    		}
+    	}
+    	return sanitized;
     }
 
     private static String getCommandErrorOutput(final InputStream commandStdoutOrNull,

--- a/src/main/java/hudson/plugins/accurev/AccurevSCM.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevSCM.java
@@ -624,14 +624,18 @@ public class AccurevSCM extends SCM {
 			boolean capturedChangelog = false;
 			boolean foundChange = false;
 			List<String> changedStreams = new ArrayList<String>();
-			do {
+			int count = 0;
+			do outer: {
 				// This is a best effort to get as close to the changes as possible
 				if (!foundChange) {
+					System.out.println("DEBUGPOINT: COUNT: "+count);
 					foundChange = checkStreamForChanges(server, accurevEnv, workspace, listener, accurevPath, launcher,
 							stream.getName(), startTime == null ? null : startTime.getTime(), false);
 				}
 				if (foundChange) {
+					int innercount = 0;
 					do {
+						System.out.println("DEBUGPOINT: SECOND NESTED THING:  COUNT: "+count+"   INNERCOUNT: "+innercount);
 						File streamChangeLog = XmlConsolidateStreamChangeLog.getStreamChangeLogFile(changelogFile, stream);
 						capturedChangelog = captureChangelog(server, accurevEnv, workspace, listener, accurevPath, launcher,
 								startDateOfPopulate, startTime == null ? null : startTime
@@ -640,7 +644,15 @@ public class AccurevSCM extends SCM {
 							changedStreams.add(streamChangeLog.getName());
 						}
 						stream = stream.getParent();
+						innercount++;
+						if (useIgnoreDeep && (count+innercount) > ignoreDeepAmount) {
+							break outer;
+						}
 					} while (stream != null && stream.isReceivingChangesFromParent() && capturedChangelog && startTime != null);
+				}
+				count++;
+				if (useIgnoreDeep && count > ignoreDeepAmount) {
+					break outer;
 				}
 				if (stream != null) {
 					stream = stream.getParent();

--- a/src/main/java/hudson/plugins/accurev/AccurevSCM.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevSCM.java
@@ -87,6 +87,7 @@ public class AccurevSCM extends SCM {
     private final int ignoreDeepAmount;
     private final String snapshotNameFormat;
     private final boolean synctime;
+    private final boolean includeMode;
     private final String workspace;
     private final String workspaceSubPath;
 	private final List<String> ignoreFilesPatterns;
@@ -114,6 +115,7 @@ public class AccurevSCM extends SCM {
                       boolean useIgnoreDeep,
                       int ignoreDeepAmount,
                       boolean useIgnoreFiles,
+                      boolean includeMode,
                       List<String> ignoreFilesPatterns) {
         super();
         this.serverName = serverName;
@@ -132,6 +134,7 @@ public class AccurevSCM extends SCM {
         this.useIgnoreDeep = useIgnoreDeep;
         this.ignoreDeepAmount = ignoreDeepAmount;
         this.useIgnoreFiles = useIgnoreFiles;
+        this.includeMode = includeMode;
         this.ignoreFilesPatterns = ignoreFilesPatterns;
     }
 
@@ -1219,9 +1222,9 @@ public class AccurevSCM extends SCM {
         
         final ICmdOutputXmlParser<Boolean, List<AccurevTransaction>> parser;
         if (isPolling && useIgnoreFiles) {
-        	parser = new ParseHistory(ignoreFilesPatterns);
+        	parser = new ParseHistory(ignoreFilesPatterns, includeMode);
         } else {
-        	parser = new ParseHistory(null);
+        	parser = new ParseHistory(null, includeMode);
         }
         
         // execute code that extracts the latest transaction
@@ -1358,6 +1361,10 @@ public class AccurevSCM extends SCM {
 		return useIgnoreFiles;
 	}
 
+	public boolean isIncludeMode() {
+		return includeMode;
+	}
+
 	public static final class AccurevSCMDescriptor extends SCMDescriptor<AccurevSCM> implements ModelObject {
 
         /**
@@ -1431,6 +1438,7 @@ public class AccurevSCM extends SCM {
                     req.getParameter("accurev.useIgnoreDeep") != null,
                     ignoreDeep,
                     req.getParameter("accurev.useIgnoreFiles") != null,
+                    req.getParameter("accurev.includeMode") != null,
                     filePatterns);
         }
         

--- a/src/main/java/hudson/plugins/accurev/AccurevSCM.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevSCM.java
@@ -417,12 +417,13 @@ public class AccurevSCM extends SCM {
                 addServer(chwscmd, server);
                 chwscmd.add("-w");
                 chwscmd.add(this.workspace);
-
-                if (!localStream.equals(accurevWorkspace.getStream().getParent().getName())) {
-                    listener.getLogger().println("Parent stream needs to be updated.");
-                    needsRelocation = true;
-                    chwscmd.add("-b");
-                    chwscmd.add(localStream);
+                if (!isIgnoreStreamParent()) { //workspace.getStream == null if it never generated parent list
+	                if (!localStream.equals(accurevWorkspace.getStream().getParent().getName())) {
+	                    listener.getLogger().println("Parent stream needs to be updated.");
+	                    needsRelocation = true;
+	                    chwscmd.add("-b");
+	                    chwscmd.add(localStream);
+	                }
                 }
                 if (!accurevWorkspace.getHost().equals(remoteDetails.getHostName())) {
                     listener.getLogger().println("Host needs to be updated.");
@@ -445,9 +446,11 @@ public class AccurevSCM extends SCM {
                     listener.getLogger().println("  New host: " + remoteDetails.getHostName());
                     listener.getLogger().println("  Old storage: " + oldStorage);
                     listener.getLogger().println("  New storage: " + remoteDetails.getPath());
-                    listener.getLogger().println("  Old parent stream: " + accurevWorkspace.getStream().getParent()
-                            .getName());
-                    listener.getLogger().println("  New parent stream: " + localStream);
+                    if (!isIgnoreStreamParent()) { //workspace.getStream == null if it never generated parent list
+	                    listener.getLogger().println("  Old parent stream: " + accurevWorkspace.getStream().getParent()
+	                            .getName());
+	                    listener.getLogger().println("  New parent stream: " + localStream);
+                    }
                     if (!AccurevLauncher.runCommand("Workspace relocation command", launcher, chwscmd, null,
                             getOptionalLock(), accurevEnv, workspace, listener, logger, true)) {
                         return false;

--- a/src/main/java/hudson/plugins/accurev/AccurevSCM.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevSCM.java
@@ -628,14 +628,12 @@ public class AccurevSCM extends SCM {
 			do outer: {
 				// This is a best effort to get as close to the changes as possible
 				if (!foundChange) {
-					System.out.println("DEBUGPOINT: COUNT: "+count);
 					foundChange = checkStreamForChanges(server, accurevEnv, workspace, listener, accurevPath, launcher,
 							stream.getName(), startTime == null ? null : startTime.getTime(), false);
 				}
 				if (foundChange) {
 					int innercount = 0;
 					do {
-						System.out.println("DEBUGPOINT: SECOND NESTED THING:  COUNT: "+count+"   INNERCOUNT: "+innercount);
 						File streamChangeLog = XmlConsolidateStreamChangeLog.getStreamChangeLogFile(changelogFile, stream);
 						capturedChangelog = captureChangelog(server, accurevEnv, workspace, listener, accurevPath, launcher,
 								startDateOfPopulate, startTime == null ? null : startTime

--- a/src/main/java/hudson/plugins/accurev/AccurevTransaction.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevTransaction.java
@@ -64,11 +64,11 @@ public final class AccurevTransaction extends ChangeLogSet.Entry {
     }
 
     public String getMsg() {
-        return msg;
+        return (msg == null ? "" : msg);
     }
 
     public void setMsg(String msg) {
-        this.msg = msg;
+        this.msg = ( msg == null ? "" : msg) ;
     }
 
     public void setAction(String action) {

--- a/src/main/java/hudson/plugins/accurev/ParseHistory.java
+++ b/src/main/java/hudson/plugins/accurev/ParseHistory.java
@@ -14,10 +14,12 @@ import org.xmlpull.v1.XmlPullParserException;
 
 final class ParseHistory implements ICmdOutputXmlParser<Boolean, List<AccurevTransaction>> {
 	private List<String> ignoreFilePatterns;
+	private boolean includeMode;
 	private static final Logger logger = Logger.getLogger(ParseHistory.class.getName());
 	
-	public ParseHistory(List<String> ignoreFilesPatterns) {
+	public ParseHistory(List<String> ignoreFilesPatterns, boolean includeMode) {
 		this.ignoreFilePatterns = ignoreFilesPatterns;
+		this.includeMode = includeMode;
 	}
 
 	public Boolean parse(XmlPullParser parser, List<AccurevTransaction> context) throws UnhandledAccurevCommandOutput,
@@ -88,10 +90,12 @@ final class ParseHistory implements ICmdOutputXmlParser<Boolean, List<AccurevTra
 	
 	private boolean isAcceptable(String pathName) throws Exception {
 		for (String regex: ignoreFilePatterns) {
-    		if (pathName.matches(regex)) {
+    		if (!includeMode && pathName.matches(regex)) {
     			return false;
+    		} else if (includeMode && pathName.matches(regex)) {
+    			return true;
     		}
     	}
-		return true;
+		return !includeMode;
 	}
 }

--- a/src/main/java/hudson/plugins/accurev/ParseHistory.java
+++ b/src/main/java/hudson/plugins/accurev/ParseHistory.java
@@ -4,19 +4,31 @@ import hudson.plugins.accurev.AccurevLauncher.ICmdOutputXmlParser;
 import hudson.plugins.accurev.AccurevLauncher.UnhandledAccurevCommandOutput;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 final class ParseHistory implements ICmdOutputXmlParser<Boolean, List<AccurevTransaction>> {
-    public Boolean parse(XmlPullParser parser, List<AccurevTransaction> context) throws UnhandledAccurevCommandOutput,
+	private List<String> ignoreFilePatterns;
+	private static final Logger logger = Logger.getLogger(ParseHistory.class.getName());
+	
+	public ParseHistory(List<String> ignoreFilesPatterns) {
+		this.ignoreFilePatterns = ignoreFilesPatterns;
+	}
+
+	public Boolean parse(XmlPullParser parser, List<AccurevTransaction> context) throws UnhandledAccurevCommandOutput,
             IOException, XmlPullParserException {
+		List<AccurevTransaction> tempList = new ArrayList();
         AccurevTransaction resultTransaction = null;
         while (parser.next() != XmlPullParser.END_DOCUMENT) {
             if (parser.getEventType() == XmlPullParser.START_TAG) {
                 if (parser.getName().equalsIgnoreCase("transaction")) {
-                    resultTransaction = new AccurevTransaction();
+                	resultTransaction = new AccurevTransaction();
+                	tempList.add(resultTransaction);
                     // parse transaction-values
                     resultTransaction.setId((Integer.parseInt(parser.getAttributeValue("", "id"))));
                     resultTransaction.setAction(parser.getAttributeValue("", "type"));
@@ -26,10 +38,60 @@ final class ParseHistory implements ICmdOutputXmlParser<Boolean, List<AccurevTra
                 } else if (parser.getName().equalsIgnoreCase("comment")) {
                     // parse comments
                     resultTransaction.setMsg(parser.nextText());
-                }
+                } else if (parser.getName().equalsIgnoreCase("version")) {
+					String path = parser.getAttributeValue("", "path");
+					if (path != null) {
+						path = path.replace("\\", "/");
+						if (path.startsWith("/./")) {
+							path = path.substring(3);
+						}
+					}
+					resultTransaction.addAffectedPath(path);
+				}
             }
         }
-        context.add(resultTransaction);
-        return Boolean.valueOf(resultTransaction != null);
+
+        if (ignoreFilePatterns != null) {
+        	for (AccurevTransaction trans : tempList) {
+        		if (isTransactionAcceptableThroughFilter(trans.getAffectedPaths())) {
+        			context.add(trans);
+        		}
+        	}
+        } else {
+        	context.addAll(tempList);
+        }
+       
+        return context.size() != 0;
     }
+	
+	protected boolean isTransactionAcceptableThroughFilter(Collection<String> filePaths) {
+		if (filePaths == null || filePaths.isEmpty()) {
+			return true;  //Could be chstream chws or any other transaction that has potential of many silent file changes
+		}
+		
+		try {
+    		for (String pathName : filePaths) {
+    			if (isAcceptable(pathName)) {
+    				return true; //if any one file is good then the whole commits gotta be considered.
+    			}
+    		}
+    		logger.info("Found the following paths but all are actively ignored for polling, ignoring this transaction: "+filePaths);
+    		return false;
+    	} catch (Exception e) {
+    		//If your regex is all derped up, lets err on side of more builds and assume the transaction contains valid files.
+    		logger.warning("Regular expression filtering caused exception, "+e.getMessage()+ " :::  marking transaction as acceptable, dumping inputs!");
+    		logger.info("File paths: "+filePaths);
+    		logger.info("Regexes: "+ignoreFilePatterns);
+    		return true;
+    	}
+	}
+	
+	private boolean isAcceptable(String pathName) throws Exception {
+		for (String regex: ignoreFilePatterns) {
+    		if (pathName.matches(regex)) {
+    			return false;
+    		}
+    	}
+		return true;
+	}
 }

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
@@ -53,6 +53,13 @@
         <f:entry title="Ignore parent changes" help="/plugin/accurev/help/project/ignore-stream-parent.html">
             <f:checkbox name="accurev.ignoreStreamParent" checked="${scm.ignoreStreamParent}"/>
         </f:entry>
+        <f:optionalBlock title="Ignore deep stream parents for polling"
+                         help="/plugin/accurev/help/project/ignore-deep-parents.html"
+                         name="accurev.ignoreDeep" checked="${scm.useIgnoreDeep}">
+            <f:entry title="# of Parent streams to poll for SCM changes">
+                <f:textbox name="accurev.ignoreDeepAmount" value="${scm.ignoreDeepAmount}"/>
+            </f:entry>
+        </f:optionalBlock>
     </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
@@ -53,12 +53,22 @@
         <f:entry title="Ignore parent changes" help="/plugin/accurev/help/project/ignore-stream-parent.html">
             <f:checkbox name="accurev.ignoreStreamParent" checked="${scm.ignoreStreamParent}"/>
         </f:entry>
-        <f:optionalBlock title="Ignore deep stream parents for polling"
+        <f:optionalBlock title="Ignore deep stream parents when polling"
                          help="/plugin/accurev/help/project/ignore-deep-parents.html"
                          name="accurev.ignoreDeep" checked="${scm.useIgnoreDeep}">
             <f:entry title="# of Parent streams to poll for SCM changes">
                 <f:textbox name="accurev.ignoreDeepAmount" value="${scm.ignoreDeepAmount}"/>
             </f:entry>
+        </f:optionalBlock>
+        <f:optionalBlock title="Ignore specific file names when polling"
+                         help="/plugin/accurev/help/project/ignore-file-names.html"
+                         name="accurev.useIgnoreFiles" checked="${scm.useIgnoreFiles}">
+            	<f:entry title="Regex to exclude:">
+	            	<f:repeatable items="${scm.ignoreFilesPatterns}" var="patterns" minimum="1">
+	            		<f:textbox name="accurev.ignoreFilesPatterns" value="${patterns}" />
+	            		<f:repeatableDeleteButton/>
+	            	</f:repeatable>
+            	</f:entry>
         </f:optionalBlock>
     </f:advanced>
 

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
@@ -55,7 +55,7 @@
         </f:entry>
         <f:optionalBlock title="Ignore deep stream parents when polling"
                          help="/plugin/accurev/help/project/ignore-deep-parents.html"
-                         name="accurev.ignoreDeep" checked="${scm.useIgnoreDeep}">
+                         name="accurev.useIgnoreDeep" checked="${scm.useIgnoreDeep}">
             <f:entry title="# of Parent streams to poll for SCM changes">
                 <f:textbox name="accurev.ignoreDeepAmount" value="${scm.ignoreDeepAmount}"/>
             </f:entry>

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
@@ -63,7 +63,10 @@
         <f:optionalBlock title="Ignore specific file names when polling"
                          help="/plugin/accurev/help/project/ignore-file-names.html"
                          name="accurev.useIgnoreFiles" checked="${scm.useIgnoreFiles}">
-            	<f:entry title="Regex to exclude:">
+                <f:entry title="Include Mode?">
+		            <f:checkbox name="accurev.includeMode" checked="${scm.includeMode}"/>
+		        </f:entry>
+            	<f:entry title="Regexes:">
 	            	<f:repeatable items="${scm.ignoreFilesPatterns}" var="patterns" minimum="1">
 	            		<f:textbox name="accurev.ignoreFilesPatterns" value="${patterns}" />
 	            		<f:repeatableDeleteButton/>

--- a/src/main/webapp/help/project/ignore-deep-parents.html
+++ b/src/main/webapp/help/project/ignore-deep-parents.html
@@ -1,0 +1,11 @@
+<div>
+	<p>
+		If checked then:<br/>
+		<br />
+		This number defines the number of streams to walk up when querying for changes.  <br/>
+		In a structure where streams look like ROOT -> A -> B -> C -> D, if this job's stream is D, and this value is set to 1, it will query for changes in D and C, but not B, A, or ROOT. <br/>
+		The actual update will bring in all new files, even if they were promoted directly to A, but this will clamp down on build trigger polls.
+		<br />
+		Do NOT enable this alongside "Ignore parent changes" - too lazy to write a compound validator or trim that old code, but this replaces and augments that configs functionality.
+	</p>
+</div>

--- a/src/main/webapp/help/project/ignore-file-names.html
+++ b/src/main/webapp/help/project/ignore-file-names.html
@@ -2,8 +2,11 @@
 	<p>
 		If checked then:<br/>
 		<br />
-		All polling will have its file results filtered through these regular expressions. (Standard java regex impl syntax)<br/>
-		Any file change found to be matching any of the regexes will be ignored and will not contribute to possibly triggering a build.<br/>
-		NOTE: this setting changes the behavior of polling from only pulling a single transaction to pulling the latest, which is a heavier call on both the Accurev server and the runtime of the polling.
-		</p>
+		All polling will have its file results filtered through these regular expressions. (Standard java regex syntax)<br/>
+		Example syntax:  .*\.java    to match all .java extension files, note the single escape on the .<br/>
+		Example syntax:  .*/scripts/.*    to match anything inside a dir named scripts<br/>
+		Any file change found to be matching any of the regexes will be IGNORED and will not contribute to possibly triggering a build.<br/>
+		File paths returned by accurev typically resemble: "foo/bar/Baz.java", note the use of unix-style file seperators.</br>
+		NOTE: this setting changes the behavior of polling from only polling a single transaction and testing transaction # high watermarks to polling the latest and testing all of the retrieved files, which is a heavier call on both the Accurev server and the runtime of the polling.
+	</p>
 </div>

--- a/src/main/webapp/help/project/ignore-file-names.html
+++ b/src/main/webapp/help/project/ignore-file-names.html
@@ -5,7 +5,8 @@
 		All polling will have its file results filtered through these regular expressions. (Standard java regex syntax)<br/>
 		Example syntax:  .*\.java    to match all .java extension files, note the single escape on the .<br/>
 		Example syntax:  .*/scripts/.*    to match anything inside a dir named scripts<br/>
-		Any file change found to be matching any of the regexes will be IGNORED and will not contribute to possibly triggering a build.<br/>
+		<p>In EXCLUDE mode (Default, unchecked) Any file change found to be matching any of the regexes will be IGNORED and will not contribute to possibly triggering a build.</p>
+		<p>In INCLUDE mode (Checked) Any file change NOT found to be matching any of the regexes will be IGNORED and will not contribute to possibly triggering a build.</p>
 		File paths returned by accurev typically resemble: "foo/bar/Baz.java", note the use of unix-style file seperators.</br>
 		NOTE: this setting changes the behavior of polling from only polling a single transaction and testing transaction # high watermarks to polling the latest and testing all of the retrieved files, which is a heavier call on both the Accurev server and the runtime of the polling.
 	</p>

--- a/src/main/webapp/help/project/ignore-file-names.html
+++ b/src/main/webapp/help/project/ignore-file-names.html
@@ -1,0 +1,9 @@
+<div>
+	<p>
+		If checked then:<br/>
+		<br />
+		All polling will have its file results filtered through these regular expressions. (Standard java regex impl syntax)<br/>
+		Any file change found to be matching any of the regexes will be ignored and will not contribute to possibly triggering a build.<br/>
+		NOTE: this setting changes the behavior of polling from only pulling a single transaction to pulling the latest, which is a heavier call on both the Accurev server and the runtime of the polling.
+		</p>
+</div>

--- a/src/test/java/hudson/plugins/accurev/AccurevLauncherTest.java
+++ b/src/test/java/hudson/plugins/accurev/AccurevLauncherTest.java
@@ -1,0 +1,59 @@
+package hudson.plugins.accurev;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AccurevLauncherTest {
+	
+	AccurevLauncher launcher;
+	Method ourMethod;
+	
+	@Before
+	public void setup() throws Exception {
+		launcher = new AccurevLauncher();
+		//Dont want to bother with trying to mock up all the data that a testHarness really should be responsible for... reflect it out
+		ourMethod = AccurevLauncher.class.getDeclaredMethod("maskPasswordFromLogOutput", String.class);
+		ourMethod.setAccessible(true);
+	}
+	
+	@After
+	public void teardown(){
+		launcher = null;
+		ourMethod = null;
+	}
+	
+	@Test
+	public void loginFails_NeedsToMasksPassword_perm1() throws Exception{
+		String permutation1 = "accurev.exe login -H somehost:1234 -n thisisme thisIsMyPassword";
+		assertEquals("accurev.exe login -H somehost:1234 -n thisisme ***********", ourMethod.invoke(launcher, permutation1));
+	}
+	
+	@Test
+	public void loginFails_NeedsToMasksPassword_perm2() throws Exception{
+		String permutation2 = "accurev.exe login -H somehost:1234 thisisme thisIsMyPassword";
+		assertEquals("accurev.exe login -H somehost:1234 thisisme ***********", ourMethod.invoke(launcher, permutation2));
+	}
+	
+	@Test
+	public void loginFails_NeedsToMasksPassword_perm3() throws Exception{
+		String permutation3 = "accurev.exe login -H somehost:1234 -n thisisme th!sIsMyP4ssword!#@!&$1237t7";
+		assertEquals("accurev.exe login -H somehost:1234 -n thisisme ***********", ourMethod.invoke(launcher, permutation3));
+	}
+	
+	@Test
+	public void loginFails_NeedsToMasksPassword_perm4() throws Exception{
+		String permutation4 = "\"C:\\program files\\derp\\accurev.exe\" login -H somehost:1234 -n thisisme thisIsMyPassword";
+		assertEquals("\"C:\\program files\\derp\\accurev.exe\" login -H somehost:1234 -n thisisme ***********", ourMethod.invoke(launcher, permutation4));
+	}
+	
+	@Test
+	public void loginFails_NeedsToMasksPassword_perm5() throws Exception{
+		String permutation5 = "accurev.exe login -n thisisme thisIsMyPassword";
+		assertEquals("accurev.exe login -n thisisme ***********", ourMethod.invoke(launcher, permutation5));
+	}
+}

--- a/src/test/java/hudson/plugins/accurev/AccurevLauncherTest.java
+++ b/src/test/java/hudson/plugins/accurev/AccurevLauncherTest.java
@@ -56,4 +56,16 @@ public class AccurevLauncherTest {
 		String permutation5 = "accurev.exe login -n thisisme thisIsMyPassword";
 		assertEquals("accurev.exe login -n thisisme ***********", ourMethod.invoke(launcher, permutation5));
 	}
+	
+	@Test
+	public void loginFails_NeedsToMasksPassword_perm6() throws Exception{
+		String permutation6 = "accurev.exe login -H somehostwithlogininitsnameforsomereason:1234 -n thisisme thisIsMyPassword";
+		assertEquals("accurev.exe login -H somehostwithlogininitsnameforsomereason:1234 -n thisisme ***********", ourMethod.invoke(launcher, permutation6));
+	}
+	
+	@Test
+	public void loginFails_NeedsToMasksPassword_perm7() throws Exception{
+		String permutation7 = "accurev.exe update -H somehostwithlogininitsnameforsomereason:1234 someworkspace thisisntrelatedtologins";
+		assertEquals("accurev.exe update -H somehostwithlogininitsnameforsomereason:1234 someworkspace thisisntrelatedtologins", ourMethod.invoke(launcher, permutation7));
+	}
 }

--- a/src/test/java/hudson/plugins/accurev/AccurevTransactionTest.java
+++ b/src/test/java/hudson/plugins/accurev/AccurevTransactionTest.java
@@ -1,0 +1,34 @@
+package hudson.plugins.accurev;
+
+import static org.junit.Assert.*;
+import hudson.MarkupText;
+import hudson.model.AbstractBuild;
+import hudson.scm.ChangeLogAnnotator;
+import hudson.scm.ChangeLogSet.Entry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AccurevTransactionTest {
+	
+	AccurevTransaction trans;
+	
+	@Before
+	public void setup(){
+		trans = new AccurevTransaction();
+	}
+	
+	@After
+	public void teardown(){
+		trans = null;
+	}
+	
+	@Test
+	public void neverReturnsNullMsg(){
+		//even if this somehow gets null stored into it, never return it back.  screws with other plugins
+		trans.setMsg(null);
+		assertNotNull(trans.getMsg());
+		assertEquals("", trans.getMsg());
+	}
+}

--- a/src/test/java/hudson/plugins/accurev/ParseHistoryTest.java
+++ b/src/test/java/hudson/plugins/accurev/ParseHistoryTest.java
@@ -16,9 +16,9 @@ public class ParseHistoryTest {
 				new String[]{"foo/bar/baz.java", "derp/herp/waffles.properties", "lots/of/changes/in/everywhere/Things.java"});
 		List<String> filters = Arrays.asList( new String[]{} );
 		
-		ParseHistory parser = new ParseHistory(filters);
+		ParseHistory parser = new ParseHistory(filters, false);
 		assertTrue("This should be valid, no filters = no reason to reject transaction", parser.isTransactionAcceptableThroughFilter(files));
-		assertTrue("This should be valid, null filter = no reason to reject transaction", new ParseHistory(null).isTransactionAcceptableThroughFilter(files));	
+		assertTrue("This should be valid, null filter = no reason to reject transaction", new ParseHistory(null, false).isTransactionAcceptableThroughFilter(files));	
 	}
 	
 	@Test
@@ -26,7 +26,7 @@ public class ParseHistoryTest {
 		List<String> files = Arrays.asList( new String[]{});
 		List<String> filters = Arrays.asList( new String[]{".*\\.java"} );
 		
-		ParseHistory parser = new ParseHistory(filters);
+		ParseHistory parser = new ParseHistory(filters, false);
 		assertTrue("This should be valid, no files = something like a chstream which can effect lots w/o direct output, err on the side of caution", 
 				parser.isTransactionAcceptableThroughFilter(files));	
 		}
@@ -38,7 +38,7 @@ public class ParseHistoryTest {
 				new String[]{"foo/bar/baz.java", "derp/herp/waffles.properties", "lots/of/changes/in/everywhere/Things.java"});
 		List<String> filters = Arrays.asList( new String[]{".*\\.java"} );  //properties file will still match.
 		
-		ParseHistory parser = new ParseHistory(filters);
+		ParseHistory parser = new ParseHistory(filters, false);
 		assertTrue("This should be valid", parser.isTransactionAcceptableThroughFilter(files));
 	}
 	
@@ -48,7 +48,7 @@ public class ParseHistoryTest {
 				new String[]{"foo/bar/baz.java", "derp/herp/waffles.properties", "lots/of/changes/in/everywhere/Things.java"});
 		List<String> filters = Arrays.asList( new String[]{".*derp.*", ".*changes.*"} );  //baz.java still matches
 		
-		ParseHistory parser = new ParseHistory(filters);
+		ParseHistory parser = new ParseHistory(filters, false);
 		assertTrue("This should be valid", parser.isTransactionAcceptableThroughFilter(files));
 	}
 	
@@ -58,7 +58,27 @@ public class ParseHistoryTest {
 				new String[]{"foo/bar/baz.java", "derp/herp/waffles.properties", "lots/of/changes/in/everywhere/Things.java"});
 		List<String> filters = Arrays.asList( new String[]{".*\\.java",".*\\.properties"} );  //all gone
 		
-		ParseHistory parser = new ParseHistory(filters);
+		ParseHistory parser = new ParseHistory(filters, false);
 		assertFalse("This should be rejected", parser.isTransactionAcceptableThroughFilter(files));
+	}
+	
+	@Test
+	public void filterCollectionOfFiles_validTrans_IncludeMode() {
+		List<String> files = Arrays.asList( 
+				new String[]{"foo/bar/baz.java", "derp/herp/waffles.properties", "lots/of/changes/in/everywhere/Things.java"});
+		List<String> filters = Arrays.asList( new String[]{".*\\.java"} );  //both java files will match.
+		
+		ParseHistory parser = new ParseHistory(filters, false);
+		assertTrue("This should be valid", parser.isTransactionAcceptableThroughFilter(files));
+	}
+	
+	@Test
+	public void filterCollectionOfFiles_invalidTrans_IncludeMode() {
+		List<String> files = Arrays.asList( 
+				new String[]{"foo/bar/baz.java", "derp/herp/waffles.properties", "lots/of/changes/in/everywhere/Things.java"});
+		List<String> filters = Arrays.asList( new String[]{".*\\.xml"} );  //no xml files
+		
+		ParseHistory parser = new ParseHistory(filters, true);
+		assertFalse("This should be invalid", parser.isTransactionAcceptableThroughFilter(files));
 	}
 }

--- a/src/test/java/hudson/plugins/accurev/ParseHistoryTest.java
+++ b/src/test/java/hudson/plugins/accurev/ParseHistoryTest.java
@@ -1,0 +1,64 @@
+package hudson.plugins.accurev;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class ParseHistoryTest {
+	
+	@Test
+	public void filterCollectionOfFiles_validTrans_noFilter() {
+		List<String> files = Arrays.asList( 
+				new String[]{"foo/bar/baz.java", "derp/herp/waffles.properties", "lots/of/changes/in/everywhere/Things.java"});
+		List<String> filters = Arrays.asList( new String[]{} );
+		
+		ParseHistory parser = new ParseHistory(filters);
+		assertTrue("This should be valid, no filters = no reason to reject transaction", parser.isTransactionAcceptableThroughFilter(files));
+		assertTrue("This should be valid, null filter = no reason to reject transaction", new ParseHistory(null).isTransactionAcceptableThroughFilter(files));	
+	}
+	
+	@Test
+	public void filterCollectionOfFiles_validTrans_noFiles() {
+		List<String> files = Arrays.asList( new String[]{});
+		List<String> filters = Arrays.asList( new String[]{".*\\.java"} );
+		
+		ParseHistory parser = new ParseHistory(filters);
+		assertTrue("This should be valid, no files = something like a chstream which can effect lots w/o direct output, err on the side of caution", 
+				parser.isTransactionAcceptableThroughFilter(files));	
+		}
+	
+	
+	@Test
+	public void filterCollectionOfFiles_validTrans_filtered() {
+		List<String> files = Arrays.asList( 
+				new String[]{"foo/bar/baz.java", "derp/herp/waffles.properties", "lots/of/changes/in/everywhere/Things.java"});
+		List<String> filters = Arrays.asList( new String[]{".*\\.java"} );  //properties file will still match.
+		
+		ParseHistory parser = new ParseHistory(filters);
+		assertTrue("This should be valid", parser.isTransactionAcceptableThroughFilter(files));
+	}
+	
+	@Test
+	public void filterCollectionOfFiles_validTrans_multipleFilters() {
+		List<String> files = Arrays.asList( 
+				new String[]{"foo/bar/baz.java", "derp/herp/waffles.properties", "lots/of/changes/in/everywhere/Things.java"});
+		List<String> filters = Arrays.asList( new String[]{".*derp.*", ".*changes.*"} );  //baz.java still matches
+		
+		ParseHistory parser = new ParseHistory(filters);
+		assertTrue("This should be valid", parser.isTransactionAcceptableThroughFilter(files));
+	}
+	
+	@Test
+	public void filterCollectionOfFiles_invalidTrans_multipleFilters() {
+		List<String> files = Arrays.asList( 
+				new String[]{"foo/bar/baz.java", "derp/herp/waffles.properties", "lots/of/changes/in/everywhere/Things.java"});
+		List<String> filters = Arrays.asList( new String[]{".*\\.java",".*\\.properties"} );  //all gone
+		
+		ParseHistory parser = new ParseHistory(filters);
+		assertFalse("This should be rejected", parser.isTransactionAcceptableThroughFilter(files));
+	}
+}


### PR DESCRIPTION
getMsg() must never return null - see ChangeSet javadoc.

Selecting "ignore parent streams" causes NullPointerExceptions upon build start.  ignoreStreamParent flow never sets accurevWorkspace.stream.parent because it is not relevant, but then the logging around chws flow accesses it