### PR TITLE
Fix JENKINS-19925

### DIFF
--- a/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
@@ -192,11 +192,10 @@ public final class AccurevLauncher {
                 listenerToLogFailuresTo, loggerToLogFailuresTo, new ICmdOutputParser<TResult, TContext>() {
                     public TResult parse(InputStream cmdOutput, TContext context) throws UnhandledAccurevCommandOutput,
                             IOException {
-                        final InputStreamReader readableXmlStream = new InputStreamReader(cmdOutput);
                         XmlPullParser parser = null;
                         try {
                             parser = xmlParserFactory.newPullParser();
-                            parser.setInput(readableXmlStream);
+                            parser.setInput(cmdOutput, null);
                             final TResult result = commandOutputParser.parse(parser, context);
                             parser.setInput(null);
                             parser = null;
@@ -214,7 +213,7 @@ public final class AccurevLauncher {
                                             humanReadableCommandName, ex, loggerToLogFailuresTo,
                                             listenerToLogFailuresTo);
                                 }
-                                readableXmlStream.close();
+                                cmdOutput.close();
                             }
                         }
                     }


### PR DESCRIPTION
Issue #JENKINS-19925 - AccuRev plugins cannot parse XML data outputed from accurev.exe hist command on non UTF-8 environments
