### PR TITLE
Log more quietly when there is not an error.

### DIFF
--- a/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
@@ -441,10 +441,10 @@ public final class AccurevLauncher {
             final FilePath directoryToRunCommandFrom, //
             final Logger loggerToLogFailuresTo, //
             final TaskListener taskListener) {
-        if (loggerToLogFailuresTo != null && loggerToLogFailuresTo.isLoggable(Level.INFO)) {
+        if (loggerToLogFailuresTo != null && loggerToLogFailuresTo.isLoggable(Level.FINE)) {
             final String hostname = getRemoteHostname(directoryToRunCommandFrom);
             final String msg = hostname + ": " + command.toStringWithQuote();
-            loggerToLogFailuresTo.log(Level.INFO, msg);
+            loggerToLogFailuresTo.log(Level.FINE, msg);
         }
     }
 


### PR DESCRIPTION
Observed a user of this plugin whose main log file was mostly filled with messages from `AccurevLauncher.logCommandExecution`, obscuring interesting warnings. There is no reason to log every command at `INFO`; if someone is interested in seeing exactly what is going on, they can create a custom logger for the plugin recording `FINE`.
