### PR TITLE
Fix for skipping poll for active projects

### DIFF
--- a/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
@@ -331,8 +331,7 @@ public final class AccurevLauncher {
             final InputStream commandStderrOrNull, //
             final Logger loggerToLogFailuresTo, //
             final TaskListener taskListener) {
-        //final String msg = commandDescription + " (" + command.toStringWithQuote() + ")" + " failed with exit code " + commandExitCode;
-        final String msg = "Failed authentication. (failed with exit code " + commandExitCode+" )";
+        final String msg = commandDescription + " (" + command.toStringWithQuote() + ")" + " failed with exit code " + commandExitCode;
         String stderr = null;
         try {
             stderr = getCommandErrorOutput(commandStdoutOrNull, commandStderrOrNull);

--- a/src/main/java/hudson/plugins/accurev/AccurevSCM.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevSCM.java
@@ -349,24 +349,21 @@ public class AccurevSCM extends SCM {
 
     @Override
     public boolean requiresWorkspaceForPolling() {
+        if (DESCRIPTOR.isPollOnMaster()) {
+            // Polling on master; workspace not required.
+            return false;
+        }
+
         if (activeProject != null && !activeProject.isBuilding()) {
             // Check if project is no longer active.
             activeProject = null;
         }
 
-        if (!DESCRIPTOR.isPollOnMaster()
-                || (AccurevMode.findMode(this).isRequiresWorkspace())
-                || (activeProject != null)) {
-            // Workspace is not required or project is already being build.
-            // If the workspace is in use, it will cause a long wait otherwise, thus skip the poll.
-            return false;
+        if (AccurevMode.findMode(this).isRequiresWorkspace() && activeProject == null) {
+            return true;
         }
 
-        // No longer have an active project that requires a workspace.
-        activeProject = null;
-
-        // No workspace needed.
-        return true;
+        return false;
     }
 
     /**
@@ -407,13 +404,13 @@ public class AccurevSCM extends SCM {
                                                    @Nullable FilePath workspace, @Nonnull TaskListener listener,
                                                    @Nonnull SCMRevisionState baseline) throws IOException, InterruptedException {
 //        TODO: Implement SCMRevisionState?
-		if (activeProject == null) {												   
-            activeProject = project;
-        } else {
+		if (activeProject != null && activeProject.isBuilding()) {
             // Skip polling while there is an active project.
             // This will prevent waiting for the workspace to become available.
             return PollingResult.NO_CHANGES;
         }
+        activeProject = project;
+
         AbstractModeDelegate delegate = AccurevMode.findDelegate(this);
         return delegate.compareRemoteRevisionWith(project, launcher, workspace, listener, baseline);
     }

--- a/src/main/java/hudson/plugins/accurev/AccurevSCM.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevSCM.java
@@ -349,9 +349,14 @@ public class AccurevSCM extends SCM {
 
     @Override
     public boolean requiresWorkspaceForPolling() {
+        if (activeProject != null && !activeProject.isBuilding()) {
+            // Check if project is no longer active.
+            activeProject = null;
+        }
+
         if (!DESCRIPTOR.isPollOnMaster()
                 || (AccurevMode.findMode(this).isRequiresWorkspace())
-                || (activeProject != null && activeProject.isBuilding())) {
+                || (activeProject != null)) {
             // Workspace is not required or project is already being build.
             // If the workspace is in use, it will cause a long wait otherwise, thus skip the poll.
             return false;

--- a/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
@@ -86,6 +86,8 @@ public abstract class AbstractModeDelegate {
             return PollingResult.NO_CHANGES;
         }
         if (jenkinsWorkspace == null) {
+            listener.getLogger().println("No workspace required.");
+
             // If we're claiming not to need a workspace in order to poll, then
             // workspace will be null.  In that case, we need to run directly
             // from the project folder on the master.


### PR DESCRIPTION
As mentioned in PR #24, we still experienced some issues with the previous change.
I've tested this on our environment and this does work without any problems.