### PR TITLE
getServer: Use serverName when serverUUID is null

### DIFF
--- a/src/main/java/hudson/plugins/accurev/AccurevSCM.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevSCM.java
@@ -183,10 +183,10 @@ public class AccurevSCM extends SCM {
             server = DESCRIPTOR.getServer(serverName);
             if (server != null) {
                 this.setServerUUID(server.getUUID());
+                DESCRIPTOR.save();
             }
         } else {
             server = DESCRIPTOR.getServer(serverUUID);
-            DESCRIPTOR.save();
         }
         return server;
     }

--- a/src/main/java/hudson/plugins/accurev/AccurevSCM.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevSCM.java
@@ -169,10 +169,26 @@ public class AccurevSCM extends SCM {
     /**
      * Getter for Accurev server
      *
-     * @return AccurevServer based on serverUUID
+     * @return AccurevServer based on serverUUID (or serverName if serverUUID is null)
      */
     public AccurevServer getServer() {
-        return DESCRIPTOR.getServer(serverUUID);
+        AccurevServer server;
+        if (serverUUID == null) {
+            final Logger log = Logger.getGlobal();
+            if (serverName == null) {
+                // No fallback
+                log.severe("AccurevSCM.getServer called but serverName and serverUUID are NULL!");
+                return null;
+            }
+            log.warning("Getting server by name (" + serverName + "), because UUID is not set.");
+            server = DESCRIPTOR.getServer(serverName);
+            if (server != null) {
+                this.setServerUUID(server.getUUID());
+            }
+        } else {
+            server = DESCRIPTOR.getServer(serverUUID);
+        }
+        return server;
     }
 
     /**

--- a/src/main/java/hudson/plugins/accurev/AccurevSCM.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevSCM.java
@@ -174,19 +174,19 @@ public class AccurevSCM extends SCM {
     public AccurevServer getServer() {
         AccurevServer server;
         if (serverUUID == null) {
-            final Logger log = Logger.getGlobal();
             if (serverName == null) {
                 // No fallback
-                log.severe("AccurevSCM.getServer called but serverName and serverUUID are NULL!");
+                logger.severe("AccurevSCM.getServer called but serverName and serverUUID are NULL!");
                 return null;
             }
-            log.warning("Getting server by name (" + serverName + "), because UUID is not set.");
+            logger.warning("Getting server by name (" + serverName + "), because UUID is not set.");
             server = DESCRIPTOR.getServer(serverName);
             if (server != null) {
                 this.setServerUUID(server.getUUID());
             }
         } else {
             server = DESCRIPTOR.getServer(serverUUID);
+            DESCRIPTOR.save();
         }
         return server;
     }

--- a/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
@@ -20,8 +20,6 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static hudson.plugins.accurev.AccurevSCM.DESCRIPTOR;
-
 /**
  * Performs actual SCM operations
  */
@@ -56,7 +54,7 @@ public abstract class AbstractModeDelegate {
         this.launcher = launcher;
         this.jenkinsWorkspace = jenkinsWorkspace;
         this.listener = listener;
-        server = DESCRIPTOR.getServer(scm.getServerUUID());
+        server = scm.getServer();
         accurevEnv = new HashMap<>();
         if (jenkinsWorkspace != null) {
             accurevWorkingSpace = new FilePath(jenkinsWorkspace, scm.getDirectoryOffset() == null ? "" : scm.getDirectoryOffset());


### PR DESCRIPTION
This should fix #JENKINS-39211.

https://issues.jenkins-ci.org/browse/JENKINS-39211