### PR TITLE
[fix/JENKINS-43457][fix/JENKINS-43657] check if workspace is empty if so do a full populate

### DIFF
--- a/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
@@ -278,19 +278,19 @@ public abstract class AbstractModeDelegate {
         }
     }
 
-    protected boolean populate(Run<?, ?> build, boolean populateRequired) throws IOException {
+    protected boolean populate(Run<?, ?> build, boolean populateRequired) throws IOException, InterruptedException {
         if (populateRequired) {
             String stream = getPopulateStream();
             int lastTransaction = NumberUtils.toInt(getLastBuildTransaction(build), 0);
             PopulateCmd pop = new PopulateCmd();
-            if (lastTransaction == 0) {
+            if (lastTransaction == 0 || accurevWorkingSpace.list("*", ".accurev").length == 0) {
                 if (pop.populate(scm, launcher, listener, server, stream, true, getPopulateFromMessage(), accurevWorkingSpace, accurevEnv,
                     null))
                     startDateOfPopulate = pop.get_startDateOfPopulate();
                 else
                     return false;
             } else {
-                String filePath = getFileRevisionsTobePopulated(build, lastTransaction, stream);
+                String filePath = getFileRevisionsTobePopulated(build, lastTransaction, getChangeLogStream());
                 logger.info("populate file path " + filePath);
                 if (filePath != null) {
                     if (pop.populate(scm, launcher, listener, server, stream, true, getPopulateFromMessage(), accurevWorkingSpace,
@@ -310,7 +310,7 @@ public abstract class AbstractModeDelegate {
         return true;
     }
 
-    protected boolean populate(Run<?, ?> build) throws IOException {
+    protected boolean populate(Run<?, ?> build) throws IOException, InterruptedException {
         return populate(build, isPopulateRequired());
     }
 

--- a/src/main/java/hudson/plugins/accurev/delegates/WorkspaceDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/WorkspaceDelegate.java
@@ -167,11 +167,6 @@ public class WorkspaceDelegate extends ReftreeDelegate {
     }
 
     @Override
-    protected String getPopulateStream() {
-        return scm.getWorkspace();
-    }
-
-    @Override
     protected void buildEnvVarsCustom(AbstractBuild<?, ?> build, Map<String, String> env) {
         env.put("ACCUREV_WORKSPACE", scm.getWorkspace());
     }


### PR DESCRIPTION
Check if jenkins workspace is empty and if so do a full populate
Also revert PR #52 :-1: Too hasty, I needed to use getChangeLogStream() for getFileRevisionsTobePopulated instead