### PR TITLE
RPI 1113039 - Jenkins: Plugin configuration that enables/disables the plugin from running jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>accurev</artifactId>
   <packaging>hpi</packaging>
-  <version>0.7.16-SNAPSHOT</version>
+  <version>0.7.17</version>
   <name>Jenkins AccuRev plugin</name>
   <description>This plugin allows you to use AccuRev as a SCM.</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/AccuRev+Plugin</url>

--- a/src/main/java/hudson/plugins/accurev/AccurevSCM.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevSCM.java
@@ -22,8 +22,6 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import net.sf.json.JSONObject;
-
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -55,6 +53,7 @@ import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Run;
 import hudson.model.StringParameterValue;
 import hudson.model.TaskListener;
+import hudson.plugins.accurev.delegates.AbstractModeDelegate;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.PollingResult;
 import hudson.scm.SCM;
@@ -64,12 +63,9 @@ import hudson.security.ACL;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
-
 import jenkins.plugins.accurev.AccurevTool;
 import jenkins.plugins.accurev.util.UUIDUtils;
-import hudson.plugins.accurev.cmd.Login;
-import hudson.plugins.accurev.cmd.ShowDepots;
-import hudson.plugins.accurev.delegates.AbstractModeDelegate;
+import net.sf.json.JSONObject;
 
 /**
  * Accurev SCM plugin for Jenkins
@@ -651,7 +647,7 @@ public class AccurevSCM extends SCM {
         }
 
         @SuppressWarnings("unused") // Used by stapler
-        public ListBoxModel doFillServerNameItems(@QueryParameter String serverName) {
+        public ListBoxModel doFillServerNameItems() {
             ListBoxModel s = new ListBoxModel();
             if (this._servers == null) {
                 DESCRIPTORLOGGER.warning("Failed to find AccuRev server. Add Server under AccuRev section in the Manage Jenkins > Configure System page.");

--- a/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
@@ -367,8 +367,8 @@ public abstract class AbstractModeDelegate {
             env.put(ACCUREV_STREAM, "");
         }
 
-        if (server != null && server.getName() != null) {
-            env.put(ACCUREV_SERVER, server.getName());
+        if (server != null && server.getHost() != null) {
+            env.put(ACCUREV_SERVER, server.getHost()+":"+server.getPort());
         } else {
             env.put(ACCUREV_SERVER, "");
         }

--- a/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
@@ -58,7 +58,7 @@ public abstract class AbstractModeDelegate {
     private static final Logger logger = Logger.getLogger(AbstractModeDelegate.class.getName());
     private static final String ACCUREV_DEPOT = "ACCUREV_DEPOT";
     private static final String ACCUREV_STREAM = "ACCUREV_STREAM";
-    private static final String ACCUREV_SERVER = "ACCUREV_SERVER";
+    private static final String ACCUREV_SERVER = "JENKINS_ACCUREV_SERVER";
     private static final String ACCUREV_SERVER_HOSTNAME = "ACCUREV_SERVER_HOSTNAME";
     private static final String ACCUREV_SERVER_PORT = "ACCUREV_SERVER_PORT";
     private static final String ACCUREV_SUBPATH = "ACCUREV_SUBPATH";
@@ -367,8 +367,8 @@ public abstract class AbstractModeDelegate {
             env.put(ACCUREV_STREAM, "");
         }
 
-        if (server != null && server.getHost() != null) {
-            env.put(ACCUREV_SERVER, server.getHost()+":"+server.getPort());
+        if (server != null && server.getName() != null) {
+            env.put(ACCUREV_SERVER, server.getName());
         } else {
             env.put(ACCUREV_SERVER, "");
         }

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/AccurevServer/config.groovy
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/AccurevServer/config.groovy
@@ -40,8 +40,7 @@ f.advanced {
     f.entry(field: "uuid", title: _("ID")) {
         f.textbox(disabled: true)
     }
-    
-     f.entry(field: "isServerDisabled", title: "Disable Plugin for this server ", help: "/plugin/accurev/help/server-disable.html") {
+    f.entry(field: "serverDisabled", title: "Disable Plugin for this server ", help: "/plugin/accurev/help/server-disable.html") {
         f.checkbox()
     }
 }

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/AccurevServer/config.groovy
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/AccurevServer/config.groovy
@@ -41,7 +41,7 @@ f.advanced {
         f.textbox(disabled: true)
     }
     
-     f.entry(field: "enablePlugin", title: "Disable Plugin for this server ", help: "/plugin/accurev/help/poll-on-master.html") {
+     f.entry(field: "isServerDisabled", title: "Disable Plugin for this server ", help: "/plugin/accurev/help/server-disable.html") {
         f.checkbox()
     }
 }

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/AccurevServer/config.groovy
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/AccurevServer/config.groovy
@@ -40,4 +40,8 @@ f.advanced {
     f.entry(field: "uuid", title: _("ID")) {
         f.textbox(disabled: true)
     }
+    
+     f.entry(field: "enablePlugin", title: "Disable Plugin for this server ", help: "/plugin/accurev/help/poll-on-master.html") {
+        f.checkbox()
+    }
 }

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
@@ -11,7 +11,10 @@
         </f:entry>
         <f:entry title="Depot ${hudson.utils.Util.filter(scms,hudson.plugins.accurev.AccurevSCM.class)}"
                  field="depot" help="/plugin/accurev/help/project/depot.html">
-          <f:textbox/>
+                  <j:if test="${descriptor.showDepot(instance.serverName)}">
+          <f:textbox disabled="true"/>
+          </j:if>
+          
         </f:entry>
         <f:entry title="Stream/Workspace ${hudson.utils.Util.filter(scms,hudson.plugins.accurev.AccurevSCM.class)}"
                  field="stream" help="/plugin/accurev/help/project/stream.html">

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
@@ -11,11 +11,11 @@
         </f:entry>
         <f:entry title="Depot ${hudson.utils.Util.filter(scms,hudson.plugins.accurev.AccurevSCM.class)}"
                  field="depot" help="/plugin/accurev/help/project/depot.html">
-               <f:textbox/>
+          <f:textbox/>
         </f:entry>
         <f:entry title="Stream/Workspace ${hudson.utils.Util.filter(scms,hudson.plugins.accurev.AccurevSCM.class)}"
                  field="stream" help="/plugin/accurev/help/project/stream.html">
-          <f:textbox/>
+          <f:textbox />
         </f:entry>
         <j:if test="${descriptor.showAccurevToolOptions()}">
           <f:entry title="${%Accurev executable}" field="accurevTool">
@@ -28,7 +28,7 @@
                           checked="${instance.useWorkspace}"
                           help="/plugin/accurev/help/project/workspace.html" inline="true">
               <f:entry title="Workspace">
-                <f:textbox name="accurev.workspace" value="${instance.workspace}"/>
+                <f:textbox name="accurev.workspace" value="${instance.workspace}" />
               </f:entry>
             </f:radioBlock>
             <f:radioBlock name="accurev.wspaceORreftree" value="reftree" title="Use Reference Tree"
@@ -47,7 +47,7 @@
               <f:textbox name="accurev.directoryOffset" value="${instance.directoryOffset}"/>
             </f:entry>
             <f:entry title="Sub-path" help="/plugin/accurev/help/project/subpath.html">
-              <f:textbox name="accurev.subPath" value="${instance.subPath}"/>
+              <f:textbox name="accurev.subPath" value="${instance.subPath}" />
             </f:entry>
             <f:entry title="Filter for Poll SCM" help="/plugin/accurev/help/project/filterforpollscm.html">
               <f:textbox name="accurev.filterForPollSCM" value="${instance.filterForPollSCM}"/>

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
@@ -11,10 +11,7 @@
         </f:entry>
         <f:entry title="Depot ${hudson.utils.Util.filter(scms,hudson.plugins.accurev.AccurevSCM.class)}"
                  field="depot" help="/plugin/accurev/help/project/depot.html">
-                  <j:if test="${descriptor.showDepot(instance.serverName)}">
-          <f:textbox disabled="true"/>
-          </j:if>
-          
+               <f:textbox/>
         </f:entry>
         <f:entry title="Stream/Workspace ${hudson.utils.Util.filter(scms,hudson.plugins.accurev.AccurevSCM.class)}"
                  field="stream" help="/plugin/accurev/help/project/stream.html">

--- a/src/main/webapp/help/project/filterforpollscm.html
+++ b/src/main/webapp/help/project/filterforpollscm.html
@@ -13,7 +13,7 @@
   </p>
 
   <p>
-    <code>src/com/my-company/main/my-file.java,src/com/test,src/com/webapp/my-file2.xml</code>
+    <code>src/com/my-company/main/my-file.java,src/com/test,src/com/webapp/my-file2.xml,src/com/*</code>
   </p>
 
   <p>

--- a/src/main/webapp/help/server-disable.html
+++ b/src/main/webapp/help/server-disable.html
@@ -1,1 +1,7 @@
-If checked, the plugin will be disabled for this particular server and no builds will be triggered.
+<div>
+  <p>
+    If checked, the plugin will be disabled for this particular server and builds will be Aborted.
+    <br/><br/>
+    This can be used when any AccuRev server is under maintenance.
+  </p>
+</div>

--- a/src/main/webapp/help/server-disable.html
+++ b/src/main/webapp/help/server-disable.html
@@ -1,0 +1,1 @@
+If checked, the plugin will be disabled for this particular server and no builds will be triggered.


### PR DESCRIPTION
ability within the AccuRev Jenkins Plug-in to be able to turn on/off (start/stop, disable/enable) the plugin from running any jobs.
I have added check box "Disable Plugin for this server" in config.groovy to turn off that particualar accurev server form building any jobs when checked. Basically i skip the checkout in AccurevSCM.java.
![image](https://user-images.githubusercontent.com/37653874/37764243-3480b460-2de7-11e8-888b-90de800837f7.png)

Whenever disabled server is selected for any job>configure>source code management>Accurev server dropdown, depot textbox sould be read-only indicating that this server is disabled.
![image](https://user-images.githubusercontent.com/37653874/37764706-5c971cae-2de8-11e8-801a-280f6d9d54d4.png)

so i put if condition in config.jelly and i am unsure of syntax i am using to call method that gives if server is on/off.

# i get compilation error:
[INFO] --- findbugs-maven-plugin:3.0.4:check (findbugs) @ accurev ---
[INFO] BugInstance size is 1
[INFO] Error size is 0
[INFO] Total bugs: 1
_[INFO] _Possible null pointer dereference in hudson.plugins.accurev.AccurevSCM$AccurevSCMDescriptor.showDepot(String) due to return value of called method [hudson.plugins.accurev.AccurevSCM$AccurevSCMDescriptor, hudson.plugins.accurev.AccurevSCM$AccurevSCMDescriptor] Dereferenced at AccurevSCM.java:[line 566]Known null at AccurevSCM.java:[line 565] NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE_
[INFO]_ 

To see bug detail using the Findbugs GUI, use the following command "mvn findbugs:gui"

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:42 min
[INFO] Finished at: 2018-03-22T15:08:00+05:30
[INFO] Final Memory: 75M/1132M
