### PR TITLE
Customer requested changes for AccuRev Plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jenkins Accurev Plugin
+# Jenkins AccuRev Plugin
 [![Build Status](https://ci.jenkins.io/job/Plugins/job/accurev-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/accurev-plugin/job/master/)
 
 Read more: [https://plugins.jenkins.io/accurev](https://plugins.jenkins.io/accurev)

--- a/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
@@ -305,17 +305,11 @@ public final class AccurevLauncher {
         return accurevTool;
     }
 
-    private static void handleConsoleMessage(TaskListener listener, boolean isValidCommand,
-            String path) {
+    private static void handleConsoleMessage(TaskListener listener, boolean isValidCommand, String path) {
         boolean isValidPath = false;
-        isValidPath = path!=null && (path.isEmpty() || path.equals("accurev"));
-        if(isValidCommand && isValidPath)
-        {
-        listener.getLogger().println(
-            String.format(
-                "No AccuRev tool configured, using default"
-            )
-        );
+        isValidPath = (path != null && (path.isEmpty() || path.equals("accurev")));
+        if (isValidCommand && isValidPath) {
+            listener.getLogger().println(String.format("No AccuRev tool configured, using default"));
         }
     }
 

--- a/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
@@ -309,7 +309,7 @@ public final class AccurevLauncher {
         boolean isValidPath = false;
         isValidPath = (path != null && (path.isEmpty() || path.equals("accurev")));
         if (isValidCommand && isValidPath) {
-            listener.getLogger().println(String.format("No AccuRev tool configured, using default"));
+            listener.getLogger().println("No AccuRev tool configured, using default");
         }
     }
 

--- a/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
@@ -291,31 +291,32 @@ public final class AccurevLauncher {
         }
     }
 
-    public static AccurevTool resolveAccurevTool(String accurevTool, TaskListener listener) {
-        if (StringUtils.isBlank(accurevTool)) {
-            AccurevTool defaultInstallation = AccurevTool.getDefaultInstallation();
-            listener.getLogger().println(
-                String.format(
-                    "No Accurv tool is chosen, reverting to %s (%s)",
-                    defaultInstallation.getName(),
-                    defaultInstallation.getHome()
-                )
-            );
-            return defaultInstallation;
+    public static AccurevTool resolveAccurevTool(String accurevToolValue, TaskListener listener, String command) {
+        AccurevTool accurevTool = Jenkins.getInstance().getDescriptorByType(AccurevTool.DescriptorImpl.class).getInstallation(accurevToolValue);
+        boolean isValidCommand = command.equals("info")||command.equals("login");
+        if (accurevTool == null ) {
+            accurevTool = AccurevTool.getDefaultInstallation();
+            String path = accurevTool.getHome();
+            handleConsoleMessage(listener, isValidCommand, path);
+        }else{
+            String path = accurevTool.getHome();
+            handleConsoleMessage(listener, isValidCommand, path);
         }
+        return accurevTool;
+    }
 
-        AccurevTool accurev = Jenkins.getInstance().getDescriptorByType(AccurevTool.DescriptorImpl.class).getInstallation(accurevTool);
-        if (accurev == null) {
-            accurev = AccurevTool.getDefaultInstallation();
-            listener.getLogger().println(
-                String.format(
-                    "Selected Accurev installation does not exist. Using Default %s (%s)",
-                    accurev.getName(),
-                    accurev.getHome()
-                )
-            );
+    private static void handleConsoleMessage(TaskListener listener, boolean isValidCommand,
+            String path) {
+        boolean isValidPath = false;
+        isValidPath = path!=null && (path.isEmpty() || path.equals("accurev"));
+        if(isValidCommand && isValidPath)
+        {
+        listener.getLogger().println(
+            String.format(
+                "No AccuRev tool configured, using default"
+            )
+        );
         }
-        return accurev;
     }
 
 
@@ -324,10 +325,11 @@ public final class AccurevLauncher {
      * @param builtOn     node where build was performed
      * @param env         environment variables used in the build
      * @param listener    build log
+     * @param command 
      * @return accurev exe for builtOn node, often "Default"
      */
-    public static String getAccurevExe(String accurevTool, Node builtOn, EnvVars env, TaskListener listener) {
-        AccurevTool tool = resolveAccurevTool(accurevTool, listener);
+    public static String getAccurevExe(String accurevTool, Node builtOn, EnvVars env, TaskListener listener, String command) {
+        AccurevTool tool = resolveAccurevTool(accurevTool, listener, command);
         if (builtOn != null) {
             try {
                 tool = tool.forNode(builtOn, listener);
@@ -364,7 +366,7 @@ public final class AccurevLauncher {
         @Nonnull TaskListener listener,
         @Nonnull final OutputStream stdoutStream,
         @Nonnull final OutputStream stderrStream, String accurevTool) throws IllegalStateException, IOException, InterruptedException {
-        String accurevPath = getAccurevExe(accurevTool, workspaceToNode(directoryToRunCommandFrom), environmentVariables, listener);
+        String accurevPath = getAccurevExe(accurevTool, workspaceToNode(directoryToRunCommandFrom), environmentVariables, listener,machineReadableCommand.toCommandArray()[0]);
         if (StringUtils.isBlank(accurevPath)) accurevPath = "accurev";
         if (!accurevPath.equals(machineReadableCommand.toCommandArray()[0]))
             machineReadableCommand.prepend(accurevPath);

--- a/src/main/java/hudson/plugins/accurev/cmd/Login.java
+++ b/src/main/java/hudson/plugins/accurev/cmd/Login.java
@@ -63,11 +63,11 @@ public class Login extends Command {
                 final String currentUsername = getLoggedInUsername(accurevTool, server, accurevEnv, pathToRunCommandsIn, listener, launcher);
                 if (StringUtils.isEmpty(currentUsername)) {
                     loginRequired = true;
-                    listener.getLogger().println("Not currently authenticated with Accurev server");
+                    listener.getLogger().println("Not currently authenticated with AccuRev server");
                 } else {
                     loginRequired = !currentUsername.equals(requiredUsername);
                     listener.getLogger().println(
-                        "Currently authenticated with Accurev server as '" + currentUsername + (loginRequired ? "', login required" : "', not logging in again."));
+                        "Currently authenticated with AccuRev server as '" + currentUsername + (loginRequired ? "', login required" : "', not logging in again."));
                 }
             } else {
                 loginRequired = true;
@@ -95,7 +95,7 @@ public class Login extends Command {
             listener.getLogger().println("Credentials username cannot be blank");
             return false;
         }
-        listener.getLogger().println("Authenticating with Accurev server...");
+        listener.getLogger().println("Authenticating with AccuRev server...");
         final ArgumentListBuilder cmd = new ArgumentListBuilder();
         cmd.add("login");
         addServer(cmd, server);

--- a/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
@@ -180,7 +180,28 @@ public abstract class AbstractModeDelegate {
             setStreamColor();
         }
 
-        return checkout(build, changelogFile) && populate(build) && captureChangeLog(build, changelogFile, streams);
+        boolean isSuccess = true;
+        String errorMessage = "Failed to";
+        if(!checkout(build, changelogFile) ){
+            errorMessage+=" checkout";
+            isSuccess = false;
+        }
+
+        if(isSuccess && !populate(build)){
+            errorMessage+=" Populate";
+            isSuccess = false;
+        }
+
+        if(isSuccess && !captureChangeLog(build, changelogFile, streams)){
+            errorMessage+=" captureChangeLog";
+            isSuccess = false;
+        }
+
+        if(!isSuccess){
+            throw new IllegalStateException(errorMessage);
+        }
+
+        return isSuccess;
 
     }
 

--- a/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/AbstractModeDelegate.java
@@ -182,22 +182,22 @@ public abstract class AbstractModeDelegate {
 
         boolean isSuccess = true;
         String errorMessage = "Failed to";
-        if(!checkout(build, changelogFile) ){
-            errorMessage+=" checkout";
+        if (!checkout(build, changelogFile)) {
+            errorMessage += " Checkout";
             isSuccess = false;
         }
 
-        if(isSuccess && !populate(build)){
-            errorMessage+=" Populate";
+        if (isSuccess && !populate(build)) {
+            errorMessage += " Populate";
             isSuccess = false;
         }
 
-        if(isSuccess && !captureChangeLog(build, changelogFile, streams)){
-            errorMessage+=" captureChangeLog";
+        if (isSuccess && !captureChangeLog(build, changelogFile, streams)) {
+            errorMessage += " CaptureChangeLog";
             isSuccess = false;
         }
 
-        if(!isSuccess){
+        if (!isSuccess) {
             throw new IllegalStateException(errorMessage);
         }
 

--- a/src/main/java/hudson/plugins/accurev/delegates/StreamDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/StreamDelegate.java
@@ -72,7 +72,7 @@ public class StreamDelegate extends AbstractModeDelegate {
         final Map<String, AccurevStream> streams = ShowStreams.getStreams(scm, localStream, server,
             accurevEnv, jenkinsWorkspace, listener, launcher);
         if (streams == null) {
-            listener.getLogger().println("Could not retrieve any Streams from Accurev, please check credentials");
+            listener.getLogger().println("Could not retrieve any Streams from AccuRev, please check credentials");
             return PollingResult.NO_CHANGES;
         }
         AccurevStream stream = streams.get(localStream);

--- a/src/main/java/jenkins/plugins/accurev/AccurevTool.java
+++ b/src/main/java/jenkins/plugins/accurev/AccurevTool.java
@@ -131,7 +131,7 @@ public class AccurevTool extends ToolInstallation implements NodeSpecific<Accure
         @Override
         @Nonnull
         public String getDisplayName() {
-            return "Accurev";
+            return "AccuRev";
         }
 
         @SuppressWarnings("SuspiciousToArrayCall")

--- a/src/main/resources/hudson/plugins/accurev/AccurevChangeLogSet/digest.jelly
+++ b/src/main/resources/hudson/plugins/accurev/AccurevChangeLogSet/digest.jelly
@@ -1,5 +1,5 @@
 <!--
-  Displays the Accurev change log digest.
+  Displays the AccuRev change log digest.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"

--- a/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/accurev/AccurevSCM/config.jelly
@@ -18,7 +18,7 @@
           <f:textbox />
         </f:entry>
         <j:if test="${descriptor.showAccurevToolOptions()}">
-          <f:entry title="${%Accurev executable}" field="accurevTool">
+          <f:entry title="${%AccuRev executable}" field="accurevTool">
             <f:select/>
           </f:entry>
         </j:if>

--- a/src/main/resources/jenkins/plugins/accurev/AccurevTool/config.groovy
+++ b/src/main/resources/jenkins/plugins/accurev/AccurevTool/config.groovy
@@ -9,6 +9,6 @@ f = namespace("/lib/form")
 f.entry(field: "name", title: _("Name")) {
     f.textbox()
 }
-f.entry(field: "home", title: _("Path to Accurev executable")) {
+f.entry(field: "home", title: _("Path to AccuRev executable")) {
     f.textbox()
 }

--- a/src/main/webapp/help/minimise-login-operations.html
+++ b/src/main/webapp/help/minimise-login-operations.html
@@ -7,9 +7,9 @@
     If not checked, an "accurev login" command will be issued before each attempt
     to poll for changes and at the start of each build.
     <br/><br/>
-    This was introduced to work around the accurev client bug whereby a
+    This was introduced to work around the AccuRev client bug whereby a
     login will first log out all active logins on that host before logging
-    in again, causing any other accurev commands running in other processes
+    in again, causing any other AccuRev commands running in other processes
     to fail due to the client (temporarily) not being logged in.
     For best effect, combine with the "-n" flag to ensure that, once logged in,
     the client stays logged in permanently.

--- a/src/main/webapp/help/poll-on-master.html
+++ b/src/main/webapp/help/poll-on-master.html
@@ -2,7 +2,7 @@
   <p>If checked then:</p>
   <ul>
     <li>
-      The plugin will (only) run accurev polling operations
+      The plugin will (only) run AccuRev polling operations
       on the master node.
     </li>
     <li>
@@ -20,5 +20,5 @@
       whether or not there are changes.
     </li>
   </ul>
-  <p>Do NOT enable this unless accurev is installed on the master node.</p>
+  <p>Do NOT enable this unless AccuRev is installed on the master node.</p>
 </div>

--- a/src/main/webapp/help/project/ignore-stream-parent.html
+++ b/src/main/webapp/help/project/ignore-stream-parent.html
@@ -5,7 +5,7 @@
     affect the contents of the stream being polled.
     <br/>
     <br/>
-    This is purely a runtime optimisation for when accurev is being used
+    This is purely a runtime optimisation for when AccuRev is being used
     as a normal VCS and not taking advantage of its stream inheritance.
     <br/>
     When used with reftree or workspaces this will be used to limit

--- a/src/main/webapp/help/project/reftree.html
+++ b/src/main/webapp/help/project/reftree.html
@@ -15,7 +15,7 @@
     build machine and relocating the reference tree to use the correct location. Note that these changes are
     recorded in the AccuRrev repository.</p>
   <p>
-    When using a reference tree, the following Accurev commands are used:
+    When using a reference tree, the following AccuRev commands are used:
   </p>
 
   <ul>

--- a/src/main/webapp/help/project/revert.html
+++ b/src/main/webapp/help/project/revert.html
@@ -1,13 +1,13 @@
 <div>
   <p>
-    This option causes the accurev plugin to revert any overlapped entries in the workspace prior to performing an
+    This option causes the AccuRev plugin to revert any overlapped entries in the workspace prior to performing an
     update of the workspace. Overlapped entries cause the update step to fail, which in turn causes the build to be
     marked
     as failed. (which in turn causes the next build to purge the workspace and therefore negate any purpose in using
     workspaces)
   </p>
   <p>
-    this option is primarily useful in cases where you are using an accurev workspace and when performing a build on
+    this option is primarily useful in cases where you are using an AccuRev workspace and when performing a build on
     that workspace
     would cause artifacts to overlap in the parent stream. If you keep getting warnings and failed builds due to
     overlaps, and you don't

--- a/src/main/webapp/help/project/update.html
+++ b/src/main/webapp/help/project/update.html
@@ -1,7 +1,7 @@
 <div>
   <p>
     By default, this plugin purges the workspace for every build. There are a number of operations
-    which when performed in Accurev, can make it impossible for a client to successfully complete
+    which when performed in AccuRev, can make it impossible for a client to successfully complete
     an <code>accurev update</code> operation with the workspace populated. The sequence of purge,
     update, populate has not failed. The down side is that it is slower.
   </p>

--- a/src/main/webapp/help/sync-operations.html
+++ b/src/main/webapp/help/sync-operations.html
@@ -14,8 +14,8 @@
     significantly in some scenarios, such as with multiple jobs with large
     checkouts.
     If you are using "accurev_login" or "custom" authentication, even on recent
-    versions of Accurev (e.g. 4.7.4 suffers from this), you need to ensure
-    that you never run a "login" unless no other accurev operations are ongoing,
-    otherwise those other accurev operations are likely to fail.
+    versions of AccuRev (e.g. 4.7.4 suffers from this), you need to ensure
+    that you never run a "login" unless no other AccuRev operations are ongoing,
+    otherwise those other AccuRev operations are likely to fail.
   </p>
 </div>

--- a/src/main/webapp/help/use-restricted-show-streams.html
+++ b/src/main/webapp/help/use-restricted-show-streams.html
@@ -9,7 +9,7 @@
     get all of the streams from the server (which can involve a lot of
     data). <br/>
     <br/>
-    This is best enabled on accurev servers with a lot of streams,
+    This is best enabled on AccuRev servers with a lot of streams,
     snapshots, workspaces etc.<br/>
     When there are relatively few streams and snapshots aren't used, it is
     typically quicker to get all the streams that the server knows about in

--- a/src/test/java/jenkins/plugins/accurev/AccurevToolTest.java
+++ b/src/test/java/jenkins/plugins/accurev/AccurevToolTest.java
@@ -67,7 +67,7 @@ public class AccurevToolTest {
     @Test
     public void testGetDescriptor() throws Exception {
         AccurevTool.DescriptorImpl descriptor = accurevTool.getDescriptor();
-        assertEquals("Accurev", descriptor.getDisplayName());
+        assertEquals("AccuRev", descriptor.getDisplayName());
     }
 
     @Test


### PR DESCRIPTION
- AccuRev Jenkins Plug-in: Misspelling and capitalization of product name AccuRev.

- AccuRev Jenkins Plug-in repeated message console output: "No Accurv tool is chosen, reverting to Default" is excess noise.

- Jenkins job should be FAILURE if AccuRev command(checkout/populate/changelogset) fails.