### PR TITLE
Fix AccuRevHiddenParametersAction when used in a Pipeline build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <revision>0.7.19</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.76</jenkins.version>
+    <jenkins.version>2.107.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <revision>0.7.19</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.60.1</jenkins.version>
+    <jenkins.version>2.76</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/src/main/java/hudson/plugins/accurev/AccuRevHiddenParametersAction.java
+++ b/src/main/java/hudson/plugins/accurev/AccuRevHiddenParametersAction.java
@@ -1,9 +1,10 @@
 package hudson.plugins.accurev;
 
 import hudson.EnvVars;
-import hudson.model.AbstractBuild;
 import hudson.model.EnvironmentContributingAction;
 import hudson.model.InvisibleAction;
+import hudson.model.Run;
+import javax.annotation.Nonnull;
 
 public class AccuRevHiddenParametersAction extends InvisibleAction
     implements EnvironmentContributingAction {
@@ -14,7 +15,8 @@ public class AccuRevHiddenParametersAction extends InvisibleAction
     this.values = values;
   }
 
-  public void buildEnvVars(AbstractBuild<?, ?> build, EnvVars env) {
+  @Override
+  public void buildEnvironment(@Nonnull Run<?, ?> run, @Nonnull EnvVars env) {
     env.putAll(values);
   }
 }


### PR DESCRIPTION
The ability to use an EnvironmentContributingAction was introduced in 2.76 (JENKINS-29537).  We need to use the new method in order for it to work.  The old deprecated method does not need to remain because the default EnvironmentContributingAction will call the new method itself. 