### PR TITLE
[JENKINS-41102] fix Job "Changes" do not match "Filter for Poll SCM"

### DIFF
--- a/src/main/java/hudson/plugins/accurev/CheckForChanges.java
+++ b/src/main/java/hudson/plugins/accurev/CheckForChanges.java
@@ -47,6 +47,7 @@ public class CheckForChanges {
     AccurevTransaction latestCodeChangeTransaction = new AccurevTransaction();
     String filterForPollSCM = scm.getFilterForPollSCM();
     String subPath = scm.getSubPath();
+    ParseChangeLog.setSubpath(subPath);
     latestCodeChangeTransaction.setDate(AccurevSCM.NO_TRANS_DATE);
 
     // query AccuRev for the latest transactions of each kind defined in transactionTypes using

--- a/src/main/java/hudson/plugins/accurev/ParseChangeLog.java
+++ b/src/main/java/hudson/plugins/accurev/ParseChangeLog.java
@@ -115,17 +115,17 @@ public class ParseChangeLog extends ChangeLogParser {
   public List<AccurevTransaction> filterBySubpath(List<AccurevTransaction> transactions) {
 
     List<AccurevTransaction> trans = new ArrayList<>();
-    logger.info("using subpath:" + getSubpath());
+    logger.fine("using subpath:" + getSubpath());
     List<String> subpaths = new ArrayList<String>();
 
     final StringTokenizer st = new StringTokenizer(getSubpath(), ",");
     while (st.hasMoreElements()) {
       String path = st.nextToken().trim();
       path = path.replace("*", "");
-      logger.info("path:" + path);
+      logger.fine("path:" + path);
       subpaths.add(path);
     }
-    logger.info("subpaths size:" + subpaths.size());
+    logger.fine("subpaths size:" + subpaths.size());
 
     for (AccurevTransaction transaction : transactions) {
 
@@ -133,13 +133,13 @@ public class ParseChangeLog extends ChangeLogParser {
       for (String rawPath : transaction.getAffectedRawPaths()) {
 
         if (isValid) {
-          logger.info("transaction is valid :" + transaction.getId());
-          logger.info("no need check files in this transaction");
+          logger.fine("transaction is valid :" + transaction.getId());
+          logger.fine("no need check files in this transaction");
           break;
         }
-        logger.info("rawPath:" + rawPath);
+        logger.fine("rawPath:" + rawPath);
         for (String subpath : subpaths) {
-          logger.info("rawPath.contains(subpath):" + rawPath.contains(subpath));
+          logger.fine("rawPath.contains(subpath):" + rawPath.contains(subpath));
           if (rawPath.contains(subpath)) {
             isValid = true;
             break;
@@ -151,9 +151,9 @@ public class ParseChangeLog extends ChangeLogParser {
 
       if (!isValid) {
         // transactions.remove(transaction);
-        logger.info("not adding  transaction to list:" + transaction.getId());
+        logger.fine("not adding  transaction to list:" + transaction.getId());
       } else {
-        logger.info("adding  transaction to list:" + transaction.getId());
+        logger.fine("adding  transaction to list:" + transaction.getId());
         trans.add(transaction);
       }
     }

--- a/src/main/java/hudson/plugins/accurev/ParseChangeLog.java
+++ b/src/main/java/hudson/plugins/accurev/ParseChangeLog.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.StringTokenizer;
 import java.util.logging.Logger;
 import jenkins.plugins.accurev.util.AccurevUtils;
+import org.apache.commons.lang.StringUtils;
 import org.xml.sax.SAXException;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -95,20 +96,18 @@ public class ParseChangeLog extends ChangeLogParser {
       filteredTransactions = transactions;
     }
     filteredTransactions.removeIf(t -> t.getAction().equalsIgnoreCase("dispatch"));
-    
-    logger.info("subpath:" + subpath);
-    if (subpath != null && !subpath.isEmpty()) {
-      logger.info("before filter by subpath process..");
-      filteredTransactions.forEach(transaction -> logger.info("transaction:" + transaction));
+
+    logger.fine("subpath:" + subpath);
+    if (StringUtils.isNotEmpty(subpath)) {
+      logger.fine("before filtering by subpath process..");
+      filteredTransactions.forEach(transaction -> logger.fine("transaction:" + transaction));
       // filtering transaction based on sub-path
-      logger.info("starting filter by subpath process..");
 
       filteredTransactions = filterBySubpath(filteredTransactions);
-      logger.info("starting filter by subpath process..");
-      logger.info("after filter by subpath process..");
-      filteredTransactions.forEach(transaction -> logger.info("transaction:" + transaction));
+      logger.fine("after filter by subpath process..");
+      filteredTransactions.forEach(transaction -> logger.fine("transaction:" + transaction));
     } else {
-      logger.info("subpath filter is not applied.");
+      logger.fine("subpath filter is not applied.");
     }
     return filteredTransactions;
   }

--- a/src/main/java/hudson/plugins/accurev/ParseChangeLog.java
+++ b/src/main/java/hudson/plugins/accurev/ParseChangeLog.java
@@ -29,7 +29,7 @@ public class ParseChangeLog extends ChangeLogParser {
 
   private static final Logger logger = Logger.getLogger(AccurevSCM.class.getName());
 
-  public static String subpath = "";
+  private static String subpath = "";
 
   public static String getSubpath() {
     return subpath;

--- a/src/main/java/hudson/plugins/accurev/delegates/ReftreeDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/ReftreeDelegate.java
@@ -44,7 +44,7 @@ public class ReftreeDelegate extends AbstractModeDelegate {
   protected PollingResult checkForChanges(Job<?, ?> project)
       throws IOException, InterruptedException {
     try {
-      logger.info("setting subpath from Reftree:" + scm.getSubPath());
+      logger.fine("setting subpath from Reftree:" + scm.getSubPath());
       ParseChangeLog.setSubpath(scm.getSubPath());
       Relocation relocation = checkForRelocation();
       if (relocation.isRelocationRequired()) {

--- a/src/main/java/hudson/plugins/accurev/delegates/ReftreeDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/ReftreeDelegate.java
@@ -6,6 +6,7 @@ import hudson.plugins.accurev.AccurevLauncher;
 import hudson.plugins.accurev.AccurevReferenceTree;
 import hudson.plugins.accurev.AccurevSCM;
 import hudson.plugins.accurev.DetermineRemoteHostname;
+import hudson.plugins.accurev.ParseChangeLog;
 import hudson.plugins.accurev.RemoteWorkspaceDetails;
 import hudson.plugins.accurev.XmlConsolidateStreamChangeLog;
 import hudson.plugins.accurev.XmlParserFactory;
@@ -43,6 +44,8 @@ public class ReftreeDelegate extends AbstractModeDelegate {
   protected PollingResult checkForChanges(Job<?, ?> project)
       throws IOException, InterruptedException {
     try {
+      logger.info("setting subpath from Reftree:" + scm.getSubPath());
+      ParseChangeLog.setSubpath(scm.getSubPath());
       Relocation relocation = checkForRelocation();
       if (relocation.isRelocationRequired()) {
         listener.getLogger().println("Relocation required triggering build");

--- a/src/main/java/hudson/plugins/accurev/delegates/SnapshotDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/SnapshotDelegate.java
@@ -4,6 +4,7 @@ import hudson.EnvVars;
 import hudson.model.Run;
 import hudson.plugins.accurev.AccurevLauncher;
 import hudson.plugins.accurev.AccurevSCM;
+import hudson.plugins.accurev.ParseChangeLog;
 import hudson.plugins.accurev.cmd.Command;
 import hudson.util.ArgumentListBuilder;
 import java.io.File;
@@ -24,6 +25,8 @@ public class SnapshotDelegate extends StreamDelegate {
 
   private String calculateSnapshotName(final Run<?, ?> build)
       throws IOException, InterruptedException {
+    logger.info("setting subpath from snapshot delegate:" + scm.getSubPath());
+    ParseChangeLog.setSubpath(scm.getSubPath());
     String snapshotNameFormat = scm.getSnapshotNameFormat();
     final String actualFormat =
         StringUtils.isBlank(snapshotNameFormat)

--- a/src/main/java/hudson/plugins/accurev/delegates/SnapshotDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/SnapshotDelegate.java
@@ -25,7 +25,7 @@ public class SnapshotDelegate extends StreamDelegate {
 
   private String calculateSnapshotName(final Run<?, ?> build)
       throws IOException, InterruptedException {
-    logger.info("setting subpath from snapshot delegate:" + scm.getSubPath());
+    logger.fine("setting subpath from snapshot delegate:" + scm.getSubPath());
     ParseChangeLog.setSubpath(scm.getSubPath());
     String snapshotNameFormat = scm.getSnapshotNameFormat();
     final String actualFormat =

--- a/src/main/java/hudson/plugins/accurev/delegates/StreamDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/StreamDelegate.java
@@ -5,6 +5,7 @@ import hudson.model.Run;
 import hudson.plugins.accurev.AccurevSCM;
 import hudson.plugins.accurev.AccurevStream;
 import hudson.plugins.accurev.CheckForChanges;
+import hudson.plugins.accurev.ParseChangeLog;
 import hudson.plugins.accurev.cmd.ShowStreams;
 import hudson.scm.PollingResult;
 import java.io.File;
@@ -64,6 +65,8 @@ public class StreamDelegate extends AbstractModeDelegate {
     final Date buildDate = lastBuild.getTimestamp().getTime();
     try {
       localStream = scm.getPollingStream(project, listener);
+      logger.info("setting subpath from stream delegate:" + scm.getSubPath());
+      ParseChangeLog.setSubpath(scm.getSubPath());
     } catch (IllegalArgumentException ex) {
       listener.getLogger().println(ex.getMessage());
       return PollingResult.NO_CHANGES;

--- a/src/main/java/hudson/plugins/accurev/delegates/StreamDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/StreamDelegate.java
@@ -65,7 +65,7 @@ public class StreamDelegate extends AbstractModeDelegate {
     final Date buildDate = lastBuild.getTimestamp().getTime();
     try {
       localStream = scm.getPollingStream(project, listener);
-      logger.info("setting subpath from stream delegate:" + scm.getSubPath());
+      logger.fine("setting subpath from stream delegate:" + scm.getSubPath());
       ParseChangeLog.setSubpath(scm.getSubPath());
     } catch (IllegalArgumentException ex) {
       listener.getLogger().println(ex.getMessage());

--- a/src/main/java/hudson/plugins/accurev/delegates/WorkspaceDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/WorkspaceDelegate.java
@@ -42,7 +42,7 @@ public class WorkspaceDelegate extends ReftreeDelegate {
   protected PollingResult checkForChanges(Job<?, ?> project)
       throws IOException, InterruptedException, IllegalArgumentException {
     localStream = scm.getPollingStream(project, listener);
-    logger.info("setting subpath from workspace delegate:" + scm.getSubPath());
+    logger.fine("setting subpath from workspace delegate:" + scm.getSubPath());
     ParseChangeLog.setSubpath(scm.getSubPath());
     return super.checkForChanges(project);
   }

--- a/src/main/java/hudson/plugins/accurev/delegates/WorkspaceDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/WorkspaceDelegate.java
@@ -6,6 +6,7 @@ import hudson.plugins.accurev.AccurevLauncher;
 import hudson.plugins.accurev.AccurevSCM;
 import hudson.plugins.accurev.AccurevStream;
 import hudson.plugins.accurev.AccurevWorkspace;
+import hudson.plugins.accurev.ParseChangeLog;
 import hudson.plugins.accurev.RemoteWorkspaceDetails;
 import hudson.plugins.accurev.XmlParserFactory;
 import hudson.plugins.accurev.cmd.Command;
@@ -41,6 +42,8 @@ public class WorkspaceDelegate extends ReftreeDelegate {
   protected PollingResult checkForChanges(Job<?, ?> project)
       throws IOException, InterruptedException, IllegalArgumentException {
     localStream = scm.getPollingStream(project, listener);
+    logger.info("setting subpath from workspace delegate:" + scm.getSubPath());
+    ParseChangeLog.setSubpath(scm.getSubPath());
     return super.checkForChanges(project);
   }
 


### PR DESCRIPTION
[Jenkins] RPI 1115588  Job "Changes" do not match "Filter for Poll SCM"

The "Changes" list on my Jenkins jobs (and
corresponding emails) using the AccuRev plugin do not match the change
detection of the job's "Filter for Poll SCM". Promotes to only the
specified sub-folder defined in "Filter for Poll SCM" are correctly
identified and kick-off the job, but the "Changes" list for the job that
gets kicked-off are all changes for the entire stream since the job
last ran, not just the changes for the sub-folder specified in "Filter
for Poll SCM".

My stream contains many sub-folders for each "package", and a Jenkins
job exists for each "package" sub-folder. With the current behavior,
irrelevant change-sets are being sent in job notification emails and
developers not involved with the changes of a specific "package" job are
being notified about success and failures even though they didn't
promote changes to said "package". Is there anyway to make the job
"Changes" list match on the changes based on "Filter for Poll SCM"?
Thanks!

Reference: SI # 3173622 - AccuRev Plugin Fix asked for by Tim Williams
https://issues.jenkins-ci.org/browse/JENKINS-41102