### PR TITLE
MicroFocus Contributed - Backward Compatibility with AccuRev Versions for improved efficiency.

### DIFF
--- a/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevLauncher.java
@@ -386,6 +386,7 @@ public final class AccurevLauncher {
   public static <TResult, TContext> TResult runJustAccurev(
       @NonNull final String humanReadableCommandName, //
       String accurevTool,
+      @NonNull final EnvVars accurevEnv,
       @NonNull final Launcher launcher, //
       @NonNull final ArgumentListBuilder machineReadableCommand, //
       @NonNull final FilePath directoryToRunCommandFrom, //
@@ -397,7 +398,17 @@ public final class AccurevLauncher {
         final ByteArrayStream stderr = new ByteArrayStream()) {
       final OutputStream stdoutStream = stdout.getOutput();
       final OutputStream stderrStream = stderr.getOutput();
-      ProcStarter starter = launcher.launch().quiet(true).cmds(machineReadableCommand);
+      String accurevPath =
+          getAccurevExe(
+              accurevTool,
+              workspaceToNode(directoryToRunCommandFrom),
+              accurevEnv,
+              listenerToLogFailuresTo,
+              machineReadableCommand.toCommandArray()[0]);
+      if (StringUtils.isBlank(accurevPath)) {
+        accurevPath = "accurev";
+      }
+      ProcStarter starter = launcher.launch().quiet(true).cmdAsSingleString(accurevPath);
       starter = starter.stdout(stdoutStream).stderr(stderrStream);
       final int commandExitCode = starter.join();
       final InputStream outputFromCommand = stdout.getInput();

--- a/src/main/java/hudson/plugins/accurev/CheckForChanges.java
+++ b/src/main/java/hudson/plugins/accurev/CheckForChanges.java
@@ -33,7 +33,7 @@ public class CheckForChanges {
    * @param buildDate build Date
    * @param logger logger
    * @param scm Accurev SCm
-   * @param ACCUREV_VERSION
+   * @param version
    * @return if there are any new transactions in the stream since the last build was done
    */
   // stream param is of type AccurevStream
@@ -47,7 +47,7 @@ public class CheckForChanges {
       Date buildDate,
       Logger logger,
       AccurevSCM scm,
-      String ACCUREV_VERSION) {
+      int version) {
     String filterForPollSCM = scm.getFilterForPollSCM();
     String subPath = scm.getSubPath();
     ParseChangeLog.setSubpath(subPath);
@@ -72,10 +72,8 @@ public class CheckForChanges {
     Set<String> pollingFilters = getListOfPollingFilters(filterForPollSCM, subPath);
 
     // AR version 7+ supports combined transaction type hist call.
-    int version = Integer.parseInt(ACCUREV_VERSION.substring(0, ACCUREV_VERSION.indexOf(".")));
     if (version < 7) {
       AccurevTransaction latestCodeChangeTransaction = new AccurevTransaction();
-
       latestCodeChangeTransaction.setDate(AccurevSCM.NO_TRANS_DATE);
 
       // query AccuRev for the latest transactions of each kind defined in transactionTypes using

--- a/src/main/java/hudson/plugins/accurev/delegates/StreamDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/StreamDelegate.java
@@ -2,12 +2,15 @@ package hudson.plugins.accurev.delegates;
 
 import hudson.model.Job;
 import hudson.model.Run;
+import hudson.plugins.accurev.AccurevLauncher;
 import hudson.plugins.accurev.AccurevSCM;
 import hudson.plugins.accurev.AccurevStream;
 import hudson.plugins.accurev.CheckForChanges;
 import hudson.plugins.accurev.ParseChangeLog;
 import hudson.plugins.accurev.cmd.ShowStreams;
+import hudson.plugins.accurev.parsers.output.ParseAccuRevVersion;
 import hudson.scm.PollingResult;
+import hudson.util.ArgumentListBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
@@ -88,6 +91,19 @@ public class StreamDelegate extends AbstractModeDelegate {
           .println("Tried to find '" + localStream + "' Stream, could not found it.");
       return PollingResult.NO_CHANGES;
     }
+    // command to get version of accurev
+    final ArgumentListBuilder cmd = new ArgumentListBuilder();
+    cmd.add("accurev");
+    String ACCUREV_VERSION =
+        AccurevLauncher.runJustAccurev(
+            "Accurev version command",
+            scm.getAccurevTool(),
+            launcher,
+            cmd,
+            jenkinsWorkspace,
+            listener,
+            logger,
+            new ParseAccuRevVersion());
     // There may be changes in a parent stream that we need to factor in.
     do {
       if (CheckForChanges.checkStreamForChanges(
@@ -99,7 +115,8 @@ public class StreamDelegate extends AbstractModeDelegate {
           stream,
           buildDate,
           logger,
-          scm)) {
+          scm,
+          ACCUREV_VERSION)) {
         return PollingResult.BUILD_NOW;
       }
       stream = stream.getParent();

--- a/src/main/java/hudson/plugins/accurev/delegates/StreamDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/StreamDelegate.java
@@ -98,12 +98,24 @@ public class StreamDelegate extends AbstractModeDelegate {
         AccurevLauncher.runJustAccurev(
             "Accurev version command",
             scm.getAccurevTool(),
+            accurevEnv,
             launcher,
             cmd,
             jenkinsWorkspace,
             listener,
             logger,
             new ParseAccuRevVersion());
+    listener
+        .getLogger()
+        .println( //
+            "Accurev Client Version: " + ACCUREV_VERSION);
+    int version = Integer.parseInt(ACCUREV_VERSION.substring(0, ACCUREV_VERSION.indexOf(".")));
+    if (version < 7) {
+      listener
+          .getLogger()
+          .println( //
+              "Upgrade AccuRev Client for improved performance");
+    }
     // There may be changes in a parent stream that we need to factor in.
     do {
       if (CheckForChanges.checkStreamForChanges(
@@ -116,7 +128,7 @@ public class StreamDelegate extends AbstractModeDelegate {
           buildDate,
           logger,
           scm,
-          ACCUREV_VERSION)) {
+          version)) {
         return PollingResult.BUILD_NOW;
       }
       stream = stream.getParent();

--- a/src/main/java/hudson/plugins/accurev/parsers/output/ParseAccuRevVersion.java
+++ b/src/main/java/hudson/plugins/accurev/parsers/output/ParseAccuRevVersion.java
@@ -1,0 +1,29 @@
+package hudson.plugins.accurev.parsers.output;
+
+import hudson.plugins.accurev.AccurevLauncher.ICmdOutputParser;
+import hudson.plugins.accurev.AccurevLauncher.UnhandledAccurevCommandOutput;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+
+public final class ParseAccuRevVersion implements ICmdOutputParser<String, Void> {
+
+  @Override
+  public String parse(InputStream cmdOutput, Void context)
+      throws UnhandledAccurevCommandOutput, IOException {
+    final Reader stringReader = new InputStreamReader(cmdOutput, Charset.defaultCharset());
+    try (BufferedReader reader = new BufferedReader(stringReader)) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.contains("AccuRev")) {
+          return line.split("\\s+")[1];
+        }
+      }
+    }
+    // TODO Auto-generated method stub
+    return null;
+  }
+}

--- a/src/main/webapp/help/project/subpath.html
+++ b/src/main/webapp/help/project/subpath.html
@@ -19,7 +19,7 @@
   </p>
 
   <p>
-    <code>src/com/my-company/main/my-file.java,src/com/test,src/com/webapp/my-file2.xml</code>
+    <code>src/com/my-company/main/my-file.java,src/com/*,src/com/webapp/my-file2.xml</code>
   </p>
   <p>
     where "src" is the immediate sub-folder under your stream or reference tree.


### PR DESCRIPTION
Hist command with combined transaction types where not supported in lower version than 7.X.
Now efficiency improved code only if AccuRev is 7 or higher and same old performance code in lower versions.
We hit accurev executable command to get version and parse it with new parser ParseAccrevVersion.