### PR TITLE
switch url to point to github as wiki.jenkins.io is made read-only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <version>${revision}${changelist}</version>
   <name>Jenkins AccuRev plugin</name>
   <description>This plugin allows you to use AccuRev as a SCM.</description>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/AccuRev+Plugin</url>
+  <url>https://github.com/jenkinsci/accurev-plugin</url>
   <properties>
     <revision>0.7.21</revision>
     <changelist>-SNAPSHOT</changelist>


### PR DESCRIPTION
see https://groups.google.com/d/msgid/jenkinsci-dev/jIfr-rfo9WizBut_ApNLwBufPREsEQ3qkybbZR9ao9ITNQhi_xeTcwXcQf69xNy7MMc6kKB1du4-sutr6qedHP70Fxnx-4TsNLg0EkX2aFY%3D%40brokenco.de

@PoojaVishal we should properly move some of the documentation to some markdown files here on the github repo.