### PR TITLE
Fix null pointer exception by enabling creation of user mentioned in AccuRev Transaction

### DIFF
--- a/src/main/java/hudson/plugins/accurev/AccurevTransaction.java
+++ b/src/main/java/hudson/plugins/accurev/AccurevTransaction.java
@@ -97,7 +97,7 @@ public final class AccurevTransaction extends ChangeLogSet.Entry {
   }
 
   public void setUser(String author) {
-    this.author = User.getById(author, false);
+    this.author = User.getById(author, true);
   }
 
   @Exported


### PR DESCRIPTION
fixes #69 

Hi,
This fix is to resolve the issue when we use AccuRev-Jenkins plugin, after triggering build throws NPE as below,

_"FATAL: null
java.lang.NullPointerException
        at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:703)
        at hudson.model.Run.execute(Run.java:1919)
        at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
        at hudson.model.ResourceController.execute(ResourceController.java:97)
        at hudson.model.Executor.run(Executor.java:428)
Finished: FAILURE"_

Since this issue is occurring at different plugin, I had looked at the other thread talks about the same issue.
This change is resolving the issue when using our plugin. 
Please let me know if this solution is fine, then approve the same.