### PR TITLE
Jenkins725: Addition of -A option in AccuRev commands invoked by plugin

### DIFF
--- a/src/main/java/hudson/plugins/accurev/cmd/ChangeLogCmd.java
+++ b/src/main/java/hudson/plugins/accurev/cmd/ChangeLogCmd.java
@@ -59,6 +59,7 @@ public class ChangeLogCmd {
     ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("hist");
     Command.addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-fx");
     cmd.add("-a");
     cmd.add("-s");
@@ -125,6 +126,7 @@ public class ChangeLogCmd {
     final ArgumentListBuilder getConfigCmd = new ArgumentListBuilder();
     getConfigCmd.add("getconfig");
     Command.addServer(getConfigCmd, server);
+    AccurevLauncher.setAuthtokenOption(getConfigCmd);
     getConfigCmd.add("-s");
     getConfigCmd.add("-r");
     getConfigCmd.add("settings.xml");

--- a/src/main/java/hudson/plugins/accurev/cmd/FilesCmd.java
+++ b/src/main/java/hudson/plugins/accurev/cmd/FilesCmd.java
@@ -33,6 +33,7 @@ public class FilesCmd extends Command {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("files");
     addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-fx");
     cmd.add("-s", scm.getStream());
     cmd.add("-l", file.getRemote());

--- a/src/main/java/hudson/plugins/accurev/cmd/History.java
+++ b/src/main/java/hudson/plugins/accurev/cmd/History.java
@@ -49,6 +49,7 @@ public class History extends Command {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("hist");
     addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-fx");
     cmd.add("-p");
     cmd.add(scm.getDepot());
@@ -120,6 +121,7 @@ public class History extends Command {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("hist");
     addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-fx");
     cmd.add("-p");
     cmd.add(scm.getDepot());
@@ -184,6 +186,7 @@ public class History extends Command {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("hist");
     addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-fx");
     cmd.add("-p");
     cmd.add(scm.getDepot());

--- a/src/main/java/hudson/plugins/accurev/cmd/Login.java
+++ b/src/main/java/hudson/plugins/accurev/cmd/Login.java
@@ -140,6 +140,7 @@ public class Login extends Command {
     } else {
       cmd.add(server.getPassword(), true);
     }
+    cmd.add("-A");
     final boolean success =
         AccurevLauncher.runCommand(
             "login", accurevTool, launcher, cmd, null, accurevEnv, workspace, listener, logger);

--- a/src/main/java/hudson/plugins/accurev/cmd/PopulateCmd.java
+++ b/src/main/java/hudson/plugins/accurev/cmd/PopulateCmd.java
@@ -56,7 +56,7 @@ public class PopulateCmd extends Command {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("pop");
     addServer(cmd, server);
-
+    AccurevLauncher.setAuthtokenOption(cmd);
     if (streamName != null) {
       cmd.add("-v");
       cmd.add(streamName);

--- a/src/main/java/hudson/plugins/accurev/cmd/SetProperty.java
+++ b/src/main/java/hudson/plugins/accurev/cmd/SetProperty.java
@@ -33,6 +33,7 @@ public class SetProperty extends Command {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("setproperty");
     Command.addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-s");
     cmd.add(streamOrWorkspaceName);
     cmd.add("-r");

--- a/src/main/java/hudson/plugins/accurev/cmd/ShowDepots.java
+++ b/src/main/java/hudson/plugins/accurev/cmd/ShowDepots.java
@@ -27,6 +27,7 @@ public class ShowDepots extends Command {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("show");
     addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-fx");
     cmd.add("depots");
 

--- a/src/main/java/hudson/plugins/accurev/cmd/ShowStreams.java
+++ b/src/main/java/hudson/plugins/accurev/cmd/ShowStreams.java
@@ -68,6 +68,7 @@ public class ShowStreams extends Command {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("show");
     addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-fx");
     cmd.add("-p");
     cmd.add(depot);
@@ -133,6 +134,7 @@ public class ShowStreams extends Command {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("show");
     addServer(cmd, scm.getServer());
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-fx");
     cmd.add("-p");
     cmd.add(scm.getDepot());

--- a/src/main/java/hudson/plugins/accurev/cmd/Synctime.java
+++ b/src/main/java/hudson/plugins/accurev/cmd/Synctime.java
@@ -27,6 +27,7 @@ public class Synctime extends Command {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("synctime");
     addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     return AccurevLauncher.runCommand(
         "Synctime command",
         scm.getAccurevTool(),

--- a/src/main/java/hudson/plugins/accurev/cmd/Update.java
+++ b/src/main/java/hudson/plugins/accurev/cmd/Update.java
@@ -33,6 +33,7 @@ public class Update extends Command {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("update");
     addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-fx");
     if (reftree != null) {
       cmd.add("-r");

--- a/src/main/java/hudson/plugins/accurev/delegates/ReftreeDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/ReftreeDelegate.java
@@ -115,6 +115,7 @@ public class ReftreeDelegate extends AbstractModeDelegate {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("show");
     Command.addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-fx");
     cmd.add("refs");
     XmlPullParserFactory parser = XmlParserFactory.getFactory();
@@ -208,6 +209,7 @@ public class ReftreeDelegate extends AbstractModeDelegate {
     ArgumentListBuilder chrefcmd = new ArgumentListBuilder();
     chrefcmd.add("chref");
     Command.addServer(chrefcmd, server);
+    AccurevLauncher.setAuthtokenOption(chrefcmd);
     chrefcmd.add("-r");
     chrefcmd.add(getRefTree());
     return chrefcmd;

--- a/src/main/java/hudson/plugins/accurev/delegates/SnapshotDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/SnapshotDelegate.java
@@ -43,6 +43,7 @@ public class SnapshotDelegate extends StreamDelegate {
     final ArgumentListBuilder mksnapcmd = new ArgumentListBuilder();
     mksnapcmd.add("mksnap");
     Command.addServer(mksnapcmd, server);
+    AccurevLauncher.setAuthtokenOption(mksnapcmd);
     mksnapcmd.add("-s");
     mksnapcmd.add(snapshotName);
     mksnapcmd.add("-b");

--- a/src/main/java/hudson/plugins/accurev/delegates/WorkspaceDelegate.java
+++ b/src/main/java/hudson/plugins/accurev/delegates/WorkspaceDelegate.java
@@ -131,6 +131,7 @@ public class WorkspaceDelegate extends ReftreeDelegate {
     final ArgumentListBuilder cmd = new ArgumentListBuilder();
     cmd.add("show");
     Command.addServer(cmd, server);
+    AccurevLauncher.setAuthtokenOption(cmd);
     cmd.add("-fx");
     cmd.add("-p");
     cmd.add(depot);
@@ -174,6 +175,7 @@ public class WorkspaceDelegate extends ReftreeDelegate {
     ArgumentListBuilder chwscmd = new ArgumentListBuilder();
     chwscmd.add("chws");
     Command.addServer(chwscmd, server);
+    AccurevLauncher.setAuthtokenOption(chwscmd);
     chwscmd.add("-w");
     chwscmd.add(scm.getWorkspace());
     return chwscmd;


### PR DESCRIPTION
<!-- The change involves adding -A option in existing AccuRev commands to specify explicitly the auth token of the currently active user. This helps in maintaining AccuRev user sessions consistently. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
